### PR TITLE
CamelMicroserviceProvider should provides SPI for customized CamelContext creation

### DIFF
--- a/camel-microservice-provider/src/main/java/org/silverware/microservices/providers/camel/CamelContextFactory.java
+++ b/camel-microservice-provider/src/main/java/org/silverware/microservices/providers/camel/CamelContextFactory.java
@@ -1,0 +1,28 @@
+/*
+ * -----------------------------------------------------------------------\
+ * SilverWare
+ *  
+ * Copyright (C) 2010 - 2013 the original author or authors.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------/
+ */
+package org.silverware.microservices.providers.camel;
+
+import org.apache.camel.CamelContext;
+
+public interface CamelContextFactory {
+
+    CamelContext createCamelContext();
+
+}


### PR DESCRIPTION
Hi,

We should provide the hook for creating custom `CamelContext`. This is must-be for the any further integration efforts.

For the beginning, we can use your classpath scanning to sneak the optional `CamelContextFactory` into the bootstrap process.

Cheers!
