### PR TITLE
Add VersionEye Maven Plugin

### DIFF
--- a/microservices-bom/pom.xml
+++ b/microservices-bom/pom.xml
@@ -235,5 +235,17 @@
       </dependencies>
    </dependencyManagement>
    <build>
+      <pluginManagement>
+         <plugins>
+            <plugin>
+               <groupId>com.versioneye</groupId>
+               <artifactId>versioneye-maven-plugin</artifactId>
+               <version>3.5.1</version>
+               <configuration>
+                  <apiKey>YOUR_SECRET_API_KEY</apiKey>
+               </configuration>
+            </plugin>
+         </plugins>
+      </pluginManagement>
    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,14 @@
       <pluginManagement>
          <plugins>
             <plugin>
+               <groupId>com.versioneye</groupId>
+               <artifactId>versioneye-maven-plugin</artifactId>
+               <version>3.5.1</version>
+               <configuration>
+                  <apiKey>YOUR_SECRET_API_KEY</apiKey>
+               </configuration>
+            </plugin>
+            <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-clean-plugin</artifactId>
                <version>2.5</version>


### PR DESCRIPTION
This PR adds the VersionEye Maven Plugin to the project. That plugin can handle Maven multi modules and parent poms. Initially this command will create the project at VersionEye: 

```
mvn versioneye:create
```

I did it already for my fork. Check out the report [here](https://www.versioneye.com/user/projects/568a6e70b84c65000e210527?child=summary#tab-dependencies). 

Then on each build at TravisCI this command will update the project at VersionEye with the current dependencies: 

```
mvn versioneye:update
```

To make that work you have to add your secret API key. But Travis offers a way to encrypt secret API keys. See [here](https://docs.travis-ci.com/user/environment-variables/#Encrypted-Variables). 
