### PR TITLE
Initial pull of checkstyle. Used Google Java Style as a default configuration. Ignored build log (build.out).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ lib/plugins/*.jar
 
 src/main/native/*.so
 
+#Build log
+/build.out

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC
+            "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+            "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<module name="Checker">
+   <property name="charset" value="UTF-8" />
+
+   <property name="severity" value="warning" />
+
+   <property name="fileExtensions" value="java, properties, xml" />
+
+   <module name="FileTabCharacter">
+      <property name="eachLine" value="true" />
+   </module>
+
+   <module name="TreeWalker">
+      <module name="OuterTypeFilename" />
+      <module name="IllegalTokenText">
+         <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL" />
+         <property name="format"
+            value="\\u00(08|09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)" />
+         <property name="message"
+            value="Avoid using corresponding octal or Unicode escape." />
+      </module>
+      <module name="AvoidEscapedUnicodeCharacters">
+         <property name="allowEscapesForControlCharacters"
+            value="true" />
+         <property name="allowByTailComment" value="true" />
+         <property name="allowNonPrintableEscapes" value="true" />
+      </module>
+      <module name="LineLength">
+         <property name="max" value="100" />
+         <property name="ignorePattern"
+            value="^package.*|^import.*|a href|href|http://|https://|ftp://" />
+      </module>
+      <module name="AvoidStarImport" />
+      <module name="OneTopLevelClass" />
+      <module name="NoLineWrap" />
+      <module name="EmptyBlock">
+         <property name="option" value="TEXT" />
+         <property name="tokens"
+            value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH" />
+      </module>
+      <module name="NeedBraces" />
+      <module name="LeftCurly">
+         <property name="maxLineLength" value="100" />
+      </module>
+      <module name="RightCurly" />
+      <module name="RightCurly">
+         <property name="option" value="alone" />
+         <property name="tokens"
+            value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT" />
+      </module>
+      <module name="WhitespaceAround">
+         <property name="allowEmptyConstructors" value="true" />
+         <property name="allowEmptyMethods" value="true" />
+         <property name="allowEmptyTypes" value="true" />
+         <property name="allowEmptyLoops" value="true" />
+         <message key="ws.notFollowed"
+            value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks may only be represented as '{}' when not part of a multi-block statement (4.1.3)" />
+         <message key="ws.notPreceded"
+            value="WhitespaceAround: ''{0}'' is not preceded with whitespace." />
+      </module>
+      <module name="OneStatementPerLine" />
+      <module name="MultipleVariableDeclarations" />
+      <module name="ArrayTypeStyle" />
+      <module name="MissingSwitchDefault" />
+      <module name="FallThrough" />
+      <module name="UpperEll" />
+      <module name="ModifierOrder" />
+      <module name="EmptyLineSeparator">
+         <property name="allowNoEmptyLineBetweenFields" value="true" />
+      </module>
+      <module name="SeparatorWrap">
+         <property name="tokens" value="DOT" />
+         <property name="option" value="nl" />
+      </module>
+      <module name="SeparatorWrap">
+         <property name="tokens" value="COMMA" />
+         <property name="option" value="EOL" />
+      </module>
+      <module name="PackageName">
+         <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$" />
+         <message key="name.invalidPattern"
+            value="Package name ''{0}'' must match pattern ''{1}''." />
+      </module>
+      <module name="TypeName">
+         <message key="name.invalidPattern"
+            value="Type name ''{0}'' must match pattern ''{1}''." />
+      </module>
+      <module name="MemberName">
+         <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$" />
+         <message key="name.invalidPattern"
+            value="Member name ''{0}'' must match pattern ''{1}''." />
+      </module>
+      <module name="ParameterName">
+         <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$" />
+         <message key="name.invalidPattern"
+            value="Parameter name ''{0}'' must match pattern ''{1}''." />
+      </module>
+      <module name="CatchParameterName">
+         <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$" />
+         <message key="name.invalidPattern"
+            value="Catch parameter name ''{0}'' must match pattern ''{1}''." />
+      </module>
+      <module name="LocalVariableName">
+         <property name="tokens" value="VARIABLE_DEF" />
+         <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$" />
+         <property name="allowOneCharVarInForLoop" value="true" />
+         <message key="name.invalidPattern"
+            value="Local variable name ''{0}'' must match pattern ''{1}''." />
+      </module>
+      <module name="ClassTypeParameterName">
+         <property name="format"
+            value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)" />
+         <message key="name.invalidPattern"
+            value="Class type name ''{0}'' must match pattern ''{1}''." />
+      </module>
+      <module name="MethodTypeParameterName">
+         <property name="format"
+            value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)" />
+         <message key="name.invalidPattern"
+            value="Method type name ''{0}'' must match pattern ''{1}''." />
+      </module>
+      <module name="InterfaceTypeParameterName">
+         <property name="format"
+            value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)" />
+         <message key="name.invalidPattern"
+            value="Interface type name ''{0}'' must match pattern ''{1}''." />
+      </module>
+      <module name="NoFinalizer" />
+      <module name="GenericWhitespace">
+         <message key="ws.followed"
+            value="GenericWhitespace ''{0}'' is followed by whitespace." />
+         <message key="ws.preceded"
+            value="GenericWhitespace ''{0}'' is preceded with whitespace." />
+         <message key="ws.illegalFollow"
+            value="GenericWhitespace ''{0}'' should followed by whitespace." />
+         <message key="ws.notPreceded"
+            value="GenericWhitespace ''{0}'' is not preceded with whitespace." />
+      </module>
+      <module name="Indentation">
+         <property name="basicOffset" value="2" />
+         <property name="braceAdjustment" value="0" />
+         <property name="caseIndent" value="2" />
+         <property name="throwsIndent" value="4" />
+         <property name="lineWrappingIndentation" value="4" />
+         <property name="arrayInitIndent" value="2" />
+      </module>
+      <module name="AbbreviationAsWordInName">
+         <property name="ignoreFinal" value="false" />
+         <property name="allowedAbbreviationLength" value="1" />
+      </module>
+      <module name="OverloadMethodsDeclarationOrder" />
+      <module name="VariableDeclarationUsageDistance" />
+      <module name="CustomImportOrder">
+         <property name="customImportOrderRules"
+            value="STATIC###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE" />
+         <property name="specialImportsRegExp" value="^(io.silverware)\." />
+         <property name="sortImportsInGroupAlphabetically"
+            value="true" />
+         <property name="separateLineBetweenGroups" value="true" />
+      </module>
+      <module name="MethodParamPad" />
+      <module name="OperatorWrap">
+         <property name="option" value="NL" />
+         <property name="tokens"
+            value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR " />
+      </module>
+      <module name="AnnotationLocation">
+         <property name="tokens"
+            value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF" />
+      </module>
+      <module name="AnnotationLocation">
+         <property name="tokens" value="VARIABLE_DEF" />
+         <property name="allowSamelineMultipleAnnotations"
+            value="true" />
+      </module>
+      <module name="NonEmptyAtclauseDescription" />
+      <module name="JavadocTagContinuationIndentation" />
+      <module name="SummaryJavadoc">
+         <property name="forbiddenSummaryFragments"
+            value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )" />
+      </module>
+      <module name="JavadocParagraph" />
+      <module name="AtclauseOrder">
+         <property name="tagOrder" value="@param, @return, @throws, @deprecated" />
+         <property name="target"
+            value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF" />
+      </module>
+      <module name="JavadocMethod">
+         <property name="scope" value="public" />
+         <property name="allowMissingParamTags" value="true" />
+         <property name="allowMissingThrowsTags" value="true" />
+         <property name="allowMissingReturnTag" value="true" />
+         <property name="minLineCount" value="2" />
+         <property name="allowedAnnotations" value="Override, Test" />
+         <property name="allowThrowsTagsForSubclasses" value="true" />
+      </module>
+      <module name="MethodName">
+         <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$" />
+         <message key="name.invalidPattern"
+            value="Method name ''{0}'' must match pattern ''{1}''." />
+      </module>
+      <module name="SingleLineJavadoc">
+         <property name="ignoreInlineTags" value="false" />
+      </module>
+      <module name="EmptyCatchBlock">
+         <property name="exceptionVariableName" value="expected" />
+      </module>
+      <module name="CommentsIndentation" />
+   </module>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
    <modelVersion>4.0.0</modelVersion>
    <groupId>io.silverware</groupId>
    <artifactId>silverware-parent</artifactId>
@@ -52,6 +53,8 @@
    <properties>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <java.level>1.8</java.level>
+      <version.checkstyle>6.16.1</version.checkstyle>
+      <version.maven.checkstyle.plugin>2.17</version.maven.checkstyle.plugin>
       <version.maven.compiler>3.3</version.maven.compiler>
       <version.maven.surefire>2.18.1</version.maven.surefire>
       <version.maven.findbugs>3.0.0</version.maven.findbugs>
@@ -167,7 +170,32 @@
                   </goals>
                </execution>
             </executions>
-         </plugin>         
+         </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-checkstyle-plugin</artifactId>
+            <configuration>
+               <configLocation>checkstyle.xml</configLocation>
+               <consoleOutput>true</consoleOutput>
+               <failsOnError>true</failsOnError>
+               <includeTestSourceDirectory>true</includeTestSourceDirectory>
+            </configuration>
+            <dependencies>
+               <dependency>
+                  <groupId>com.puppycrawl.tools</groupId>
+                  <artifactId>checkstyle</artifactId>
+                  <version>${version.checkstyle}</version>
+               </dependency>
+            </dependencies>
+            <executions>
+               <execution>
+                  <id>check</id>
+                  <goals>
+                     <goal>check</goal>
+                  </goals>
+               </execution>
+            </executions>
+         </plugin>
       </plugins>
       <pluginManagement>
          <plugins>
@@ -265,6 +293,11 @@
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-javadoc-plugin</artifactId>
                <version>${version.maven.javadoc.plugin}</version>
+            </plugin>
+            <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-checkstyle-plugin</artifactId>
+               <version>${version.maven.checkstyle.plugin}</version>
             </plugin>
          </plugins>
       </pluginManagement>

--- a/travis.sh
+++ b/travis.sh
@@ -29,7 +29,7 @@ PING_LOOP_PID=$!
 # My build is using maven, but you could build anything with this, E.g.
 # your_build_command_1 >> $BUILD_OUTPUT 2>&1
 # your_build_command_2 >> $BUILD_OUTPUT 2>&1
-mvn install >> $BUILD_OUTPUT 2>&1
+mvn checkstyle::check install >> $BUILD_OUTPUT 2>&1
 
 # The build finished without returning an error so dump a tail of the output
 dump_output


### PR DESCRIPTION
Future changes are expected as this pull request uses Google Java Style as a default configuration. I only changed CustomImportOrder to include "io.silverware.*" packages.

The checkstyle::check goal is included within the travis.sh build. However, build does not fail unless severity is changed from "warning" to "error".

 I suggest the following steps that I am able to implement in the next pull request(s):
1. Define our custom check style configuration
   This is already covered here https://www.perfcake.org/docs/developers-guide/dev.contributor.developing.coding-standards.html
2. Clean up the project according the coding standards
3. Set the severity to "error"
   Pull request that does not pass coding standards of this project (successful build) will not be accepted.
