### PR TITLE
Changed checkstyle rules according to the PerfCake code formatting. C…

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -29,7 +29,7 @@
          <property name="allowNonPrintableEscapes" value="true" />
       </module>
       <module name="LineLength">
-         <property name="max" value="100" />
+         <property name="max" value="400" />
          <property name="ignorePattern"
             value="^package.*|^import.*|a href|href|http://|https://|ftp://" />
       </module>
@@ -68,9 +68,6 @@
       <module name="FallThrough" />
       <module name="UpperEll" />
       <module name="ModifierOrder" />
-      <module name="EmptyLineSeparator">
-         <property name="allowNoEmptyLineBetweenFields" value="true" />
-      </module>
       <module name="SeparatorWrap">
          <property name="tokens" value="DOT" />
          <property name="option" value="nl" />
@@ -93,23 +90,23 @@
          <message key="name.invalidPattern"
             value="Member name ''{0}'' must match pattern ''{1}''." />
       </module>
-      <module name="ParameterName">
+      <!-- <module name="ParameterName">
          <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$" />
          <message key="name.invalidPattern"
             value="Parameter name ''{0}'' must match pattern ''{1}''." />
-      </module>
-      <module name="CatchParameterName">
+      </module> -->
+      <!-- <module name="CatchParameterName">
          <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$" />
          <message key="name.invalidPattern"
             value="Catch parameter name ''{0}'' must match pattern ''{1}''." />
-      </module>
-      <module name="LocalVariableName">
+      </module> -->
+      <!-- <module name="LocalVariableName">
          <property name="tokens" value="VARIABLE_DEF" />
          <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$" />
          <property name="allowOneCharVarInForLoop" value="true" />
          <message key="name.invalidPattern"
             value="Local variable name ''{0}'' must match pattern ''{1}''." />
-      </module>
+      </module> -->
       <module name="ClassTypeParameterName">
          <property name="format"
             value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)" />
@@ -140,7 +137,7 @@
             value="GenericWhitespace ''{0}'' is not preceded with whitespace." />
       </module>
       <module name="Indentation">
-         <property name="basicOffset" value="2" />
+         <property name="basicOffset" value="3" />
          <property name="braceAdjustment" value="0" />
          <property name="caseIndent" value="2" />
          <property name="throwsIndent" value="4" />
@@ -182,13 +179,13 @@
          <property name="forbiddenSummaryFragments"
             value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )" />
       </module>
-      <module name="JavadocParagraph" />
+      <!-- <module name="JavadocParagraph" /> -->
       <module name="AtclauseOrder">
          <property name="tagOrder" value="@param, @return, @throws, @deprecated" />
          <property name="target"
             value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF" />
       </module>
-      <module name="JavadocMethod">
+      <!-- <module name="JavadocMethod">
          <property name="scope" value="public" />
          <property name="allowMissingParamTags" value="true" />
          <property name="allowMissingThrowsTags" value="true" />
@@ -196,7 +193,7 @@
          <property name="minLineCount" value="2" />
          <property name="allowedAnnotations" value="Override, Test" />
          <property name="allowThrowsTagsForSubclasses" value="true" />
-      </module>
+      </module> -->
       <module name="MethodName">
          <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$" />
          <message key="name.invalidPattern"

--- a/code-formatting/silverware-eclipse-cleanup.xml
+++ b/code-formatting/silverware-eclipse-cleanup.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="2">
+<profile kind="CleanUpProfile" name="silverware-eclipse-cleanup" version="2">
+<setting id="cleanup.qualify_static_method_accesses_with_declaring_class" value="false"/>
+<setting id="cleanup.always_use_this_for_non_static_method_access" value="false"/>
+<setting id="cleanup.organize_imports" value="true"/>
+<setting id="cleanup.remove_trailing_whitespaces_ignore_empty" value="false"/>
+<setting id="cleanup.use_type_arguments" value="false"/>
+<setting id="cleanup.format_source_code_changes_only" value="false"/>
+<setting id="cleanup.qualify_static_field_accesses_with_declaring_class" value="false"/>
+<setting id="cleanup.add_generated_serial_version_id" value="false"/>
+<setting id="cleanup.qualify_static_member_accesses_through_subtypes_with_declaring_class" value="true"/>
+<setting id="cleanup.remove_redundant_type_arguments" value="true"/>
+<setting id="cleanup.remove_unused_imports" value="true"/>
+<setting id="cleanup.insert_inferred_type_arguments" value="false"/>
+<setting id="cleanup.make_private_fields_final" value="true"/>
+<setting id="cleanup.use_lambda" value="true"/>
+<setting id="cleanup.always_use_blocks" value="true"/>
+<setting id="cleanup.use_this_for_non_static_field_access_only_if_necessary" value="true"/>
+<setting id="cleanup.sort_members_all" value="false"/>
+<setting id="cleanup.remove_trailing_whitespaces_all" value="true"/>
+<setting id="cleanup.add_missing_annotations" value="true"/>
+<setting id="cleanup.always_use_this_for_non_static_field_access" value="false"/>
+<setting id="cleanup.make_parameters_final" value="false"/>
+<setting id="cleanup.sort_members" value="false"/>
+<setting id="cleanup.remove_private_constructors" value="true"/>
+<setting id="cleanup.always_use_parentheses_in_expressions" value="false"/>
+<setting id="cleanup.remove_unused_local_variables" value="false"/>
+<setting id="cleanup.convert_to_enhanced_for_loop" value="false"/>
+<setting id="cleanup.remove_unused_private_fields" value="true"/>
+<setting id="cleanup.never_use_blocks" value="false"/>
+<setting id="cleanup.add_missing_deprecated_annotations" value="true"/>
+<setting id="cleanup.use_this_for_non_static_field_access" value="false"/>
+<setting id="cleanup.remove_unnecessary_nls_tags" value="true"/>
+<setting id="cleanup.qualify_static_member_accesses_through_instances_with_declaring_class" value="true"/>
+<setting id="cleanup.add_missing_nls_tags" value="false"/>
+<setting id="cleanup.remove_unnecessary_casts" value="true"/>
+<setting id="cleanup.use_blocks_only_for_return_and_throw" value="false"/>
+<setting id="cleanup.format_source_code" value="true"/>
+<setting id="cleanup.convert_functional_interfaces" value="false"/>
+<setting id="cleanup.add_default_serial_version_id" value="true"/>
+<setting id="cleanup.remove_unused_private_methods" value="true"/>
+<setting id="cleanup.remove_trailing_whitespaces" value="true"/>
+<setting id="cleanup.make_type_abstract_if_missing_method" value="false"/>
+<setting id="cleanup.add_serial_version_id" value="false"/>
+<setting id="cleanup.use_this_for_non_static_method_access" value="false"/>
+<setting id="cleanup.use_this_for_non_static_method_access_only_if_necessary" value="true"/>
+<setting id="cleanup.use_anonymous_class_creation" value="false"/>
+<setting id="cleanup.add_missing_override_annotations_interface_methods" value="true"/>
+<setting id="cleanup.remove_unused_private_members" value="false"/>
+<setting id="cleanup.make_local_variable_final" value="true"/>
+<setting id="cleanup.add_missing_methods" value="false"/>
+<setting id="cleanup.never_use_parentheses_in_expressions" value="true"/>
+<setting id="cleanup.qualify_static_member_accesses_with_declaring_class" value="true"/>
+<setting id="cleanup.use_parentheses_in_expressions" value="false"/>
+<setting id="cleanup.add_missing_override_annotations" value="true"/>
+<setting id="cleanup.use_blocks" value="true"/>
+<setting id="cleanup.make_variable_declarations_final" value="false"/>
+<setting id="cleanup.correct_indentation" value="true"/>
+<setting id="cleanup.remove_unused_private_types" value="true"/>
+</profile>
+</profiles>

--- a/code-formatting/silverware-eclipse-formatter.xml
+++ b/code-formatting/silverware-eclipse-formatter.xml
@@ -1,0 +1,587 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="12">
+<profile kind="CodeFormatterProfile" name="perfcake-java-profile" version="12">
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_annotation_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.indentation.size" value="3"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_anonymous_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
+<setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_binary_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+<setting id="org.eclipse.jdt.core.compiler.problem.enumIdentifier" value="error"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="200"/>
+<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_lambda_body" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.compiler.problem.assertIdentifier" value="error"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_method_body" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+<setting id="org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode" value="enabled"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+<setting id="org.eclipse.jdt.core.compiler.source" value="1.8"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="3"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_constant" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="1.8"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_type_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_lambda_arrow" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_binary_operator" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.compiler.compliance" value="1.8"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_lambda_arrow" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.lineSplit" value="400"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+</profile>
+<profile kind="CodeFormatterProfile" name="silverware" version="12">
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_annotation_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_anonymous_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
+<setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_binary_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+<setting id="org.eclipse.jdt.core.compiler.problem.enumIdentifier" value="error"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="80"/>
+<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="48"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_lambda_body" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="48"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.compiler.problem.assertIdentifier" value="error"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_method_body" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="48"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+<setting id="org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode" value="enabled"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
+<setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+<setting id="org.eclipse.jdt.core.compiler.source" value="1.8"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_constant" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="1.8"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_type_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_lambda_arrow" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_binary_operator" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.compiler.compliance" value="1.8"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_lambda_arrow" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.lineSplit" value="80"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+</profile>
+</profiles>

--- a/code-formatting/silverware.importorder
+++ b/code-formatting/silverware.importorder
@@ -1,0 +1,7 @@
+#Organize Import Order
+#Tue Mar 29 00:10:35 CEST 2016
+4=javax
+3=java
+2=
+1=io.silverware
+0=\#

--- a/microservices/src/main/java/io/silverware/microservices/Boot.java
+++ b/microservices/src/main/java/io/silverware/microservices/Boot.java
@@ -24,7 +24,6 @@ import io.silverware.microservices.util.Utils;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.GnuParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
@@ -90,6 +89,7 @@ public final class Boot {
 
    /**
     * Load custom properties from file on a classpath.
+    *
     * @return Properties from silverware.properties when present on a classpath.
     */
    private static Properties loadProperties() {
@@ -116,6 +116,7 @@ public final class Boot {
 
    /**
     * Creates initial context pre-filled with system properties, command line arguments, custom property file and default property file.
+    *
     * @param args Command line arguments.
     * @return Initial context pre-filled with system properties, command line arguments, custom property file and default property file.
     */

--- a/microservices/src/main/java/io/silverware/microservices/Context.java
+++ b/microservices/src/main/java/io/silverware/microservices/Context.java
@@ -19,14 +19,14 @@
  */
 package io.silverware.microservices;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import io.silverware.microservices.providers.MicroserviceProvider;
-import io.silverware.microservices.silver.HttpInvokerSilverService;
 import io.silverware.microservices.silver.HttpServerSilverService;
 import io.silverware.microservices.silver.ProvidingSilverService;
 import io.silverware.microservices.silver.SilverService;
 import io.silverware.microservices.silver.cluster.ServiceHandle;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -96,6 +96,7 @@ public class Context {
 
    /**
     * Gets the global properties.
+    *
     * @return The global properties.
     */
    public Map<String, Object> getProperties() {
@@ -104,6 +105,7 @@ public class Context {
 
    /**
     * Gets the registry of Microservices providers.
+    *
     * @return The registry of Microservices providers.
     */
    @SuppressWarnings("unchecked")
@@ -113,6 +115,7 @@ public class Context {
 
    /**
     * Adds a Microservice to the registry.
+    *
     * @param metaData Description of the service to be registered.
     */
    public void registerMicroservice(final MicroserviceMetaData metaData) {
@@ -121,6 +124,7 @@ public class Context {
 
    /**
     * Gets an unmodifiable copy of the current local Microservices registry.
+    *
     * @return An unmodifiable copy of the current local Microservices registry.
     */
    public Set<MicroserviceMetaData> getMicroservices() {
@@ -130,13 +134,13 @@ public class Context {
    /**
     * Looks up Microservices based on the provided meta-data query.
     * All providers are asked to look up all possible services including local and remote.
+    *
     * @param metaData Meta-data query.
     * @return A set of Microservices instances that meets the query.
     */
    public Set<Object> lookupMicroservice(final MicroserviceMetaData metaData) {
       final Set<Object> microservices = new HashSet<>();
-      getAllProviders(ProvidingSilverService.class).forEach(provider ->
-            microservices.addAll(((ProvidingSilverService) provider).lookupMicroservice(metaData)));
+      getAllProviders(ProvidingSilverService.class).forEach(provider -> microservices.addAll(((ProvidingSilverService) provider).lookupMicroservice(metaData)));
 
       return microservices;
    }
@@ -144,13 +148,13 @@ public class Context {
    /**
     * Looks up Microservices based on the provided meta-data query.
     * Only local Microservices are searched.
+    *
     * @param metaData Meta-data query.
     * @return A set of Microservices instances that meets the query.
     */
    public Set<Object> lookupLocalMicroservice(final MicroserviceMetaData metaData) {
       final Set<Object> microservices = new HashSet<>();
-      getAllProviders(ProvidingSilverService.class).forEach(provider ->
-            microservices.addAll(((ProvidingSilverService) provider).lookupLocalMicroservice(metaData)));
+      getAllProviders(ProvidingSilverService.class).forEach(provider -> microservices.addAll(((ProvidingSilverService) provider).lookupLocalMicroservice(metaData)));
 
       return microservices;
    }
@@ -210,6 +214,7 @@ public class Context {
 
    /**
     * Gets the {@link ServiceHandle} for the given handle number.
+    *
     * @param handle The handle number.
     * @return The {@link ServiceHandle} with the given handle number.
     */

--- a/microservices/src/main/java/io/silverware/microservices/Executor.java
+++ b/microservices/src/main/java/io/silverware/microservices/Executor.java
@@ -19,13 +19,14 @@
  */
 package io.silverware.microservices;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import io.silverware.microservices.providers.MicroserviceProvider;
 import io.silverware.microservices.silver.ProvidingSilverService;
 import io.silverware.microservices.util.DeployStats;
 import io.silverware.microservices.util.DeploymentScanner;
 import io.silverware.microservices.util.Utils;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
@@ -133,9 +134,10 @@ public class Executor implements MicroserviceProvider, ProvidingSilverService {
        * Creates new daemon thread with higher priority.
        *
        * @param r
-       *       Runnable for which the thread should be created-
+       *        Runnable for which the thread should be created-
        * @return The new thread.
        */
+      @Override
       public Thread newThread(final Runnable r) {
          Thread t = new Thread(group, r, namePrefix + threadNumber.getAndIncrement(), 0);
          t.setDaemon(true);
@@ -158,7 +160,7 @@ public class Executor implements MicroserviceProvider, ProvidingSilverService {
     * This creates a default empty context.
     *
     * @throws InterruptedException
-    *       If the main thread fails for any reason.
+    *         If the main thread fails for any reason.
     */
    public static void bootHook() throws InterruptedException {
       final Context context = new Context();
@@ -170,9 +172,9 @@ public class Executor implements MicroserviceProvider, ProvidingSilverService {
     * Uses an already created context.
     *
     * @param initialContext
-    *       The context associated with this platform instance.
+    *        The context associated with this platform instance.
     * @throws InterruptedException
-    *       If the main thread fails for any reason.
+    *         If the main thread fails for any reason.
     */
    public static void bootHook(final Context initialContext) throws InterruptedException {
       final Executor executor = new Executor();
@@ -190,7 +192,7 @@ public class Executor implements MicroserviceProvider, ProvidingSilverService {
     * Also counts statistics of the created instances.
     *
     * @param microserviceProviders
-    *       A set of Microservice provider classes to create their instances.
+    *        A set of Microservice provider classes to create their instances.
     */
    private void createInstances(final Set<Class<? extends MicroserviceProvider>> microserviceProviders) {
       log.info(String.format("Found %d microservice providers. Starting...", microserviceProviders.size()));

--- a/microservices/src/main/java/io/silverware/microservices/MicroserviceMetaData.java
+++ b/microservices/src/main/java/io/silverware/microservices/MicroserviceMetaData.java
@@ -19,12 +19,12 @@
  */
 package io.silverware.microservices;
 
-import com.cedarsoftware.util.io.JsonReader;
-import com.cedarsoftware.util.io.JsonWriter;
 import io.silverware.microservices.silver.HttpInvokerSilverService;
-import io.silverware.microservices.silver.cluster.Invocation;
 import io.silverware.microservices.silver.cluster.ServiceHandle;
 import io.silverware.microservices.util.Utils;
+
+import com.cedarsoftware.util.io.JsonReader;
+import com.cedarsoftware.util.io.JsonWriter;
 
 import java.lang.annotation.Annotation;
 import java.net.HttpURLConnection;
@@ -38,7 +38,7 @@ import java.util.Set;
  *
  * @author <a href="mailto:marvenec@gmail.com">Martin Večeřa</a>
  */
-final public class MicroserviceMetaData {
+public final class MicroserviceMetaData {
 
    /**
     * Name of the Microservice.
@@ -50,7 +50,8 @@ final public class MicroserviceMetaData {
     */
    private final Class type;
 
-   /**s
+   /**
+    * s
     * Qualifiers of the Microservice.
     */
    private final Set<Annotation> qualifiers;
@@ -69,11 +70,11 @@ final public class MicroserviceMetaData {
     * Create a representation of a discovered Microservice.
     *
     * @param name
-    *       The name of the discovered Microservice.
+    *        The name of the discovered Microservice.
     * @param type
-    *       The type of the discovered Microservice.
+    *        The type of the discovered Microservice.
     * @param qualifiers
-    *       The qualifiers of the discovered Microservice.
+    *        The qualifiers of the discovered Microservice.
     */
    public MicroserviceMetaData(final String name, final Class type, final Set<Annotation> qualifiers) {
       this.name = name;
@@ -91,15 +92,15 @@ final public class MicroserviceMetaData {
     * Create a representation of a discovered Microservice.
     *
     * @param name
-    *       The name of the discovered Microservice.
+    *        The name of the discovered Microservice.
     * @param type
-    *       The type of the discovered Microservice.
+    *        The type of the discovered Microservice.
     * @param qualifiers
-    *       The qualifiers of the discovered Microservice.
+    *        The qualifiers of the discovered Microservice.
     * @param specVersion
-    *       The specification version we are looking for.
+    *        The specification version we are looking for.
     * @param implVersion
-    *       The implementation version we are looking for.
+    *        The implementation version we are looking for.
     */
    public MicroserviceMetaData(final String name, final Class type, final Set<Annotation> qualifiers, final String specVersion, final String implVersion) {
       this.name = name;
@@ -142,6 +143,7 @@ final public class MicroserviceMetaData {
 
    /**
     * Gets the Microservice specification version.
+    *
     * @return The Microservice specification version.
     */
    public String getSpecVersion() {
@@ -150,6 +152,7 @@ final public class MicroserviceMetaData {
 
    /**
     * Gets the Microservice implementation version.
+    *
     * @return The Microservice implementation version.
     */
    public String getImplVersion() {
@@ -158,19 +161,24 @@ final public class MicroserviceMetaData {
 
    @Override
    public boolean equals(Object o) {
-      if (this == o)
+      if (this == o) {
          return true;
-      if (o == null || getClass() != o.getClass())
+      }
+      if (o == null || getClass() != o.getClass()) {
          return false;
+      }
 
       MicroserviceMetaData that = (MicroserviceMetaData) o;
 
-      if (!name.equals(that.name))
+      if (!name.equals(that.name)) {
          return false;
-      if (!type.equals(that.type))
+      }
+      if (!type.equals(that.type)) {
          return false;
-      if (qualifiers != null ? !qualifiers.equals(that.qualifiers) : that.qualifiers != null)
+      }
+      if (qualifiers != null ? !qualifiers.equals(that.qualifiers) : that.qualifiers != null) {
          return false;
+      }
       return !(specVersion != null ? !specVersion.equals(that.specVersion) : that.specVersion != null);
 
    }
@@ -185,8 +193,7 @@ final public class MicroserviceMetaData {
 
    @Override
    public String toString() {
-      return "microservice " + name + " of type " + type.getCanonicalName() + " with qualifiers " + Arrays.toString(qualifiers.toArray())
-            + " (version: spec. " + specVersion + ", impl. " + implVersion + ")";
+      return "microservice " + name + " of type " + type.getCanonicalName() + " with qualifiers " + Arrays.toString(qualifiers.toArray()) + " (version: spec. " + specVersion + ", impl. " + implVersion + ")";
    }
 
    @SuppressWarnings("unchecked")

--- a/microservices/src/main/java/io/silverware/microservices/SilverWareException.java
+++ b/microservices/src/main/java/io/silverware/microservices/SilverWareException.java
@@ -32,13 +32,12 @@ public class SilverWareException extends Exception {
     * Defaults to {@link java.lang.Exception#Exception(String, Throwable)}.
     *
     * @param message
-    *       The detailed message. The detailed message is saved for
-    *       later retrieval by the {@link #getMessage()} method.
+    *        The detailed message. The detailed message is saved for
+    *        later retrieval by the {@link #getMessage()} method.
     * @param cause
-    *       The cause (which is saved for later retrieval by the
-    *       {@link #getCause()} method). (A <tt>null</tt> value is
-    *       permitted, and indicates that the cause is nonexistent or
-    *       unknown.)
+    *        The cause (which is saved for later retrieval by the {@link #getCause()} method). (A <tt>null</tt> value is
+    *        permitted, and indicates that the cause is nonexistent or
+    *        unknown.)
     * @see java.lang.Exception#Exception(String, Throwable)
     */
    public SilverWareException(final String message, final Throwable cause) {
@@ -49,10 +48,9 @@ public class SilverWareException extends Exception {
     * Defaults to {@link java.lang.Exception#Exception(Throwable)}.
     *
     * @param cause
-    *       The cause (which is saved for later retrieval by the
-    *       {@link #getCause()} method). (A <tt>null</tt> value is
-    *       permitted, and indicates that the cause is nonexistent or
-    *       unknown.)
+    *        The cause (which is saved for later retrieval by the {@link #getCause()} method). (A <tt>null</tt> value is
+    *        permitted, and indicates that the cause is nonexistent or
+    *        unknown.)
     * @see java.lang.Exception#Exception(Throwable)
     */
    public SilverWareException(final Throwable cause) {
@@ -63,8 +61,8 @@ public class SilverWareException extends Exception {
     * Defaults to {@link java.lang.Exception#Exception(String)}.
     *
     * @param message
-    *       The detailed message. The detailed message is saved for
-    *       later retrieval by the {@link #getMessage()} method.
+    *        The detailed message. The detailed message is saved for
+    *        later retrieval by the {@link #getMessage()} method.
     * @see java.lang.Exception#Exception(String)
     */
    public SilverWareException(final String message) {

--- a/microservices/src/main/java/io/silverware/microservices/providers/MicroserviceProvider.java
+++ b/microservices/src/main/java/io/silverware/microservices/providers/MicroserviceProvider.java
@@ -33,5 +33,6 @@ public interface MicroserviceProvider extends Runnable {
    default void initialize(final Context context) {
    }
 
+   @Override
    void run();
 }

--- a/microservices/src/main/java/io/silverware/microservices/silver/CdiSilverService.java
+++ b/microservices/src/main/java/io/silverware/microservices/silver/CdiSilverService.java
@@ -50,6 +50,7 @@ public interface CdiSilverService extends ProvidingSilverService {
 
    /**
     * Looks up the given bean type in CDI. The particular implementation is dependant on the underlying service provider.
+    *
     * @param type The type to search for.
     * @param <T> Type of the bean to return.
     * @return Bean of the requested type.

--- a/microservices/src/main/java/io/silverware/microservices/silver/HttpServerSilverService.java
+++ b/microservices/src/main/java/io/silverware/microservices/silver/HttpServerSilverService.java
@@ -26,8 +26,7 @@ import java.util.List;
 
 /**
  * Provider of an HTTP Server.
- * Typically needed by {@link MonitoringSilverService} and or
- * {@link HttpInvokerSilverService}.
+ * Typically needed by {@link MonitoringSilverService} and or {@link HttpInvokerSilverService}.
  *
  * @author <a href="mailto:marvenec@gmail.com">Martin Večeřa</a>
  */
@@ -50,6 +49,7 @@ public interface HttpServerSilverService extends SilverService {
 
    /**
     * Deploys a servlet on the HTTP server.
+    *
     * @param contextPath Context path where the servlet should be bound.
     * @param deploymentName Name of the deployment.
     * @param servletDescriptors A list of descriptions of the servlet(s).

--- a/microservices/src/main/java/io/silverware/microservices/silver/SilverService.java
+++ b/microservices/src/main/java/io/silverware/microservices/silver/SilverService.java
@@ -30,6 +30,7 @@ public interface SilverService {
 
    /**
     * Gets the current context this instance has been created with.
+    *
     * @return The current context this instance has been created with.
     */
    Context getContext();

--- a/microservices/src/main/java/io/silverware/microservices/silver/cluster/Invocation.java
+++ b/microservices/src/main/java/io/silverware/microservices/silver/cluster/Invocation.java
@@ -19,10 +19,11 @@
  */
 package io.silverware.microservices.silver.cluster;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import io.silverware.microservices.Context;
 import io.silverware.microservices.SilverWareException;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -105,12 +106,7 @@ public class Invocation {
 
    @Override
    public String toString() {
-      return "Invocation{" +
-            "handle=" + handle +
-            ", method='" + method + '\'' +
-            ", paramTypes=" + Arrays.toString(paramTypes) +
-            ", params=" + Arrays.toString(params) +
-            '}';
+      return "Invocation{" + "handle=" + handle + ", method='" + method + '\'' + ", paramTypes=" + Arrays.toString(paramTypes) + ", params=" + Arrays.toString(params) + '}';
    }
 
    public Object invoke(final Context context) throws Exception {
@@ -128,6 +124,4 @@ public class Invocation {
       return method.invoke(serviceHandle.getService(), params);
    }
 
-
 }
-

--- a/microservices/src/main/java/io/silverware/microservices/silver/cluster/ServiceHandle.java
+++ b/microservices/src/main/java/io/silverware/microservices/silver/cluster/ServiceHandle.java
@@ -19,11 +19,12 @@
  */
 package io.silverware.microservices.silver.cluster;
 
-import com.cedarsoftware.util.io.JsonReader;
-import com.cedarsoftware.util.io.JsonWriter;
 import io.silverware.microservices.Context;
 import io.silverware.microservices.MicroserviceMetaData;
 import io.silverware.microservices.silver.HttpInvokerSilverService;
+
+import com.cedarsoftware.util.io.JsonReader;
+import com.cedarsoftware.util.io.JsonWriter;
 
 import java.io.Serializable;
 import java.net.HttpURLConnection;
@@ -40,15 +41,15 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class ServiceHandle implements Serializable {
 
-   final static transient private AtomicInteger handleSource = new AtomicInteger(0);
+   private static final transient AtomicInteger handleSource = new AtomicInteger(0);
 
-   final private int handle;
+   private final int handle;
 
-   final private String host;
+   private final String host;
 
-   final private MicroserviceMetaData query;
+   private final MicroserviceMetaData query;
 
-   final private transient Object service;
+   private final transient Object service;
 
    public ServiceHandle(final String host, final MicroserviceMetaData query, final Object service) {
       this.handle = handleSource.getAndIncrement();
@@ -108,12 +109,7 @@ public class ServiceHandle implements Serializable {
 
    @Override
    public String toString() {
-      return "ServiceHandle{" +
-            "handle=" + handle +
-            ", host='" + host + '\'' +
-            ", query=" + query +
-            ", service=" + service +
-            '}';
+      return "ServiceHandle{" + "handle=" + handle + ", host='" + host + '\'' + ", query=" + query + ", service=" + service + '}';
    }
 
    public Object invoke(final Context context, final String method, final Class[] paramTypes, final Object[] params) throws Exception {

--- a/microservices/src/main/java/io/silverware/microservices/silver/http/ServletDescriptor.java
+++ b/microservices/src/main/java/io/silverware/microservices/silver/http/ServletDescriptor.java
@@ -106,11 +106,6 @@ public class ServletDescriptor {
 
    @Override
    public String toString() {
-      return "ServletDescriptor{" +
-            "name='" + name + '\'' +
-            ", servletClass=" + servletClass +
-            ", mapping='" + mapping + '\'' +
-            ", properties=" + properties +
-            '}';
+      return "ServletDescriptor{" + "name='" + name + '\'' + ", servletClass=" + servletClass + ", mapping='" + mapping + '\'' + ", properties=" + properties + '}';
    }
 }

--- a/microservices/src/main/java/io/silverware/microservices/silver/services/LookupStrategyFactory.java
+++ b/microservices/src/main/java/io/silverware/microservices/silver/services/LookupStrategyFactory.java
@@ -19,12 +19,13 @@
  */
 package io.silverware.microservices.silver.services;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import io.silverware.microservices.Context;
 import io.silverware.microservices.MicroserviceMetaData;
 import io.silverware.microservices.annotations.InvocationPolicy;
 import io.silverware.microservices.silver.services.lookup.LocalLookupStrategy;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
@@ -43,7 +44,7 @@ public class LookupStrategyFactory {
    public static LookupStrategy getStrategy(final Context context, final MicroserviceMetaData metaData, final Set<Annotation> options) {
       LookupStrategy strategy = null;
 
-      for (Annotation option: options) {
+      for (Annotation option : options) {
          if (option.annotationType().isAssignableFrom(InvocationPolicy.class)) {
             InvocationPolicy policy = (InvocationPolicy) option;
             Class<LookupStrategy> clazz = policy.lookupStrategy();

--- a/microservices/src/main/java/io/silverware/microservices/silver/services/lookup/AbstractLookupStrategy.java
+++ b/microservices/src/main/java/io/silverware/microservices/silver/services/lookup/AbstractLookupStrategy.java
@@ -29,7 +29,7 @@ import java.util.Set;
 /**
  * @author <a href="mailto:marvenec@gmail.com">Martin Večeřa</a>
  */
-abstract public class AbstractLookupStrategy implements LookupStrategy {
+public abstract class AbstractLookupStrategy implements LookupStrategy {
 
    protected Context context;
    protected MicroserviceMetaData metaData;

--- a/microservices/src/main/java/io/silverware/microservices/util/ClassLoaderUtil.java
+++ b/microservices/src/main/java/io/silverware/microservices/util/ClassLoaderUtil.java
@@ -30,6 +30,7 @@ public final class ClassLoaderUtil {
 
    /**
     * Get URLs to basicClassLoaders and also to jars from MANIFEST Class-Path directive.
+    *
     * @param basicClassLoaders Classloaders that we want to examine.
     * @return Set of URL (not null).
     */
@@ -51,22 +52,10 @@ public final class ClassLoaderUtil {
       return result;
    }
 
-   private static Set<ClassLoader> getAlsoParentsClassLoaders(final List<ClassLoader> basicClassLoaders) {
-      final Set<ClassLoader> result = new LinkedHashSet<>(basicClassLoaders);
-      for (final ClassLoader basicClassLoader : basicClassLoaders) {
-         ClassLoader parent = basicClassLoader.getParent();
-         while (parent != null) {
-            result.add(parent);
-            parent = parent.getParent();
-         }
-      }
-      return result;
-   }
-
    private static Set<URL> getAlsoNestedClasspathUrls(ClassLoader cl) throws IOException {
       final Set<URL> result = new LinkedHashSet<>();
 
-      //add standard getURLs() urls.
+      // add standard getURLs() urls.
       if (cl instanceof URLClassLoader) {
          final URL[] urls = ((URLClassLoader) cl).getURLs();
          if (urls != null && urls.length > 0) {
@@ -74,7 +63,7 @@ public final class ClassLoaderUtil {
          }
       }
 
-      //add all other nested urls.
+      // add all other nested urls.
       final Enumeration<URL> eResource = cl.getResources("META-INF");
       while (eResource.hasMoreElements()) {
          final URL urlResource = eResource.nextElement();
@@ -88,6 +77,18 @@ public final class ClassLoaderUtil {
          }
       }
 
+      return result;
+   }
+
+   private static Set<ClassLoader> getAlsoParentsClassLoaders(final List<ClassLoader> basicClassLoaders) {
+      final Set<ClassLoader> result = new LinkedHashSet<>(basicClassLoaders);
+      for (final ClassLoader basicClassLoader : basicClassLoaders) {
+         ClassLoader parent = basicClassLoader.getParent();
+         while (parent != null) {
+            result.add(parent);
+            parent = parent.getParent();
+         }
+      }
       return result;
    }
 }

--- a/microservices/src/main/java/io/silverware/microservices/util/DeployStats.java
+++ b/microservices/src/main/java/io/silverware/microservices/util/DeployStats.java
@@ -48,6 +48,7 @@ public class DeployStats implements Serializable {
 
    /**
     * Sets the number of discovered instances.
+    *
     * @param found The number of discovered instances.
     */
    public void setFound(long found) {
@@ -70,6 +71,7 @@ public class DeployStats implements Serializable {
 
    /**
     * Gets the number of discovered instances.
+    *
     * @return The number of discovered instances.
     */
    public long getFound() {
@@ -78,6 +80,7 @@ public class DeployStats implements Serializable {
 
    /**
     * Gets the number of skipped instances.
+    *
     * @return The number of skipped instances.
     */
    public long getSkipped() {
@@ -86,6 +89,7 @@ public class DeployStats implements Serializable {
 
    /**
     * Gets the number of deployed instances.
+    *
     * @return The number of deployed instances.
     */
    public long getDeployed() {
@@ -94,8 +98,10 @@ public class DeployStats implements Serializable {
 
    /**
     * Gets the string representation of the statistics in a user friendly format.
+    *
     * @return Tthe string representation of the statistics in a user friendly format.
     */
+   @Override
    public String toString() {
       return String.format("found %d, deployed %d, skipped deployment %d", getFound(), getDeployed(), getSkipped());
    }

--- a/microservices/src/main/java/io/silverware/microservices/util/DeploymentScanner.java
+++ b/microservices/src/main/java/io/silverware/microservices/util/DeploymentScanner.java
@@ -19,10 +19,14 @@
  */
 package io.silverware.microservices.util;
 
+import io.silverware.microservices.Context;
+import io.silverware.microservices.providers.MicroserviceProvider;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.reflections.Reflections;
 import org.reflections.scanners.ResourcesScanner;
+import org.reflections.scanners.SubTypesScanner;
 import org.reflections.util.ClasspathHelper;
 import org.reflections.util.ConfigurationBuilder;
 import org.reflections.vfs.SystemDir;
@@ -43,9 +47,6 @@ import java.util.Set;
 import java.util.jar.JarFile;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
-import io.silverware.microservices.Context;
-import io.silverware.microservices.providers.MicroserviceProvider;
 
 /**
  * Scanner of classpath to search for given classes, interface implementations and others.
@@ -92,7 +93,7 @@ public class DeploymentScanner {
     * Creates an instance of the scanner that scans only in the given packages.
     *
     * @param packages
-    *       Packages to limit scanning to.
+    *        Packages to limit scanning to.
     */
    private DeploymentScanner(final String... packages) {
       final ConfigurationBuilder builder = ConfigurationBuilder.build((Object[]) packages);
@@ -119,7 +120,7 @@ public class DeploymentScanner {
     * Gets an instance of the scanner that is limited to the given packages.
     *
     * @param packages
-    *       Packages to limit scanning to.
+    *        Packages to limit scanning to.
     * @return An instance of the scanner that is limited to the given packages.
     */
    public static DeploymentScanner getInstance(final String... packages) {
@@ -127,11 +128,10 @@ public class DeploymentScanner {
    }
 
    /**
-    * Gets an instance of the scanner based on the information already stored in the provided
-    * {@link Context}.
+    * Gets an instance of the scanner based on the information already stored in the provided {@link Context}.
     *
     * @param context
-    *       A {@link Context} carrying the information needed to create the scanner.
+    *        A {@link Context} carrying the information needed to create the scanner.
     * @return An instance of the scanner based on the information already stored in the provided
     */
    public static DeploymentScanner getContextInstance(final Context context) {
@@ -159,19 +159,24 @@ public class DeploymentScanner {
     * Searches for all subtypes of the given class.
     *
     * @param clazz
-    *       A class to search subtypes of.
+    *        A class to search subtypes of.
     * @return All available classes of the given subtype.
     */
    @SuppressWarnings("unchecked")
    public Set lookupSubtypes(final Class clazz) {
       return reflections.getSubTypesOf(clazz);
+      /*final Set s1 = reflections.getSubTypesOf(clazz);
+      final Set s2 = Sets.newHashSet(ReflectionUtils.forNames(
+            reflections.getStore().getAll(TransitiveInterfacesScanner.class.getSimpleName(), Collections.singletonList(clazz.getName())), reflections.getConfiguration().getClassLoaders()));
+
+      return Sets.union(s1, s2);*/
    }
 
    /**
     * Searches for all resources matching the given pattern.
     *
     * @param pattern
-    *       The pattern to match.
+    *        The pattern to match.
     * @return All available resources matching the given pattern.
     */
    @SuppressWarnings("unchecked")
@@ -183,18 +188,18 @@ public class DeploymentScanner {
     * Creates instances of the given classes using default constructor.
     *
     * @param classes
-    *       Classes to create instances of.
+    *        Classes to create instances of.
     * @param <T>
-    *       Common type of the classes.
+    *        Common type of the classes.
     * @return Instances of the given classes.
     * @throws NoSuchMethodException
-    *       When there was no default constructor.
+    *         When there was no default constructor.
     * @throws IllegalAccessException
-    *       When the default constructor is not visible.
+    *         When the default constructor is not visible.
     * @throws InvocationTargetException
-    *       When it was not possible to invoke the constructor.
+    *         When it was not possible to invoke the constructor.
     * @throws InstantiationException
-    *       When it was not possible to create an instance.
+    *         When it was not possible to create an instance.
     */
    public static <T> List<T> instantiate(final Set<Class<T>> classes) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
       final List<T> instances = new ArrayList<>();
@@ -216,7 +221,8 @@ public class DeploymentScanner {
    }
 
    /**
-    * Add ClasspathUrls from MANIFEST Class-Path directive into builder
+    * Add ClasspathUrls from MANIFEST Class-Path directive into builder.
+    *
     * @param builder Reflection ConfigurationBuilder
     */
    private static void addNestedClasspathUrls(final ConfigurationBuilder builder) {
@@ -226,14 +232,13 @@ public class DeploymentScanner {
 
    /**
     * Remove ClasspathUrls like *.so or *.dll
+    *
     * @param builder Reflection ConfigurationBuilder
     */
    private static void removeSysLibUrls(final ConfigurationBuilder builder) {
       final Pattern sysLibPattern = Pattern.compile(".*[.](so|dll)", Pattern.CASE_INSENSITIVE);
 
-      final Set<URL> urls = builder.getUrls().stream().filter(
-            url -> !sysLibPattern.matcher(url.getFile()).matches()
-      ).collect(Collectors.toCollection(LinkedHashSet::new));
+      final Set<URL> urls = builder.getUrls().stream().filter(url -> !sysLibPattern.matcher(url.getFile()).matches()).collect(Collectors.toCollection(LinkedHashSet::new));
       builder.setUrls(urls);
    }
 
@@ -256,5 +261,33 @@ public class DeploymentScanner {
             return new ZipDir(new JarFile(file));
          }
       }
+   }
+
+   public static class TransitiveInterfacesScanner extends SubTypesScanner {
+
+      @SuppressWarnings({"unchecked"})
+      public void scan(final Object cls) {
+         final String className = getMetadataAdapter().getClassName(cls);
+
+         try {
+            Class clazz = Class.forName(className);
+
+            while (!clazz.getCanonicalName().startsWith("javax.") && !clazz.getCanonicalName().startsWith("java.") && !clazz.getCanonicalName().startsWith("com.sun.") && !clazz.getCanonicalName().startsWith("sun.")) {
+
+               for (Class anInterface : clazz.getInterfaces()) {
+                  if (acceptResult(anInterface.getCanonicalName())) {
+                     getStore().put(anInterface.getCanonicalName(), className);
+                  }
+               }
+
+               clazz = clazz.getSuperclass();
+            }
+         } catch (Throwable ex) {
+            if (log.isTraceEnabled()) {
+               log.trace("Could not load class {}", className);
+            }
+         }
+      }
+
    }
 }

--- a/microservices/src/main/java/io/silverware/microservices/util/Utils.java
+++ b/microservices/src/main/java/io/silverware/microservices/util/Utils.java
@@ -25,7 +25,6 @@ import org.apache.logging.log4j.Logger;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Enumeration;
 import java.util.Scanner;
@@ -51,6 +50,7 @@ public class Utils {
 
    /**
     * Logs a shutdown message with the given exception.
+    *
     * @param log A logger where to log the message to.
     * @param ie An exception causing the shutdown.
     */
@@ -63,6 +63,7 @@ public class Utils {
 
    /**
     * Waits for the URL to become available.
+    *
     * @param urlString The URL to check for.
     * @param code The expected HTTP response code.
     * @return Returns true if the URL was available, false otherwise.
@@ -96,6 +97,7 @@ public class Utils {
 
    /**
     * Completely reads the content of the given URL as a string.
+    *
     * @param urlString The URL to read from.
     * @return The content of the given URL.
     * @throws IOException When it was not possible to read from the URL.
@@ -106,6 +108,7 @@ public class Utils {
 
    /**
     * Gets the manifest entry for the given class.
+    *
     * @param clazz The class I want to obtain entry for.
     * @param entryName The name of the entry to obtain.
     * @return The entry from manifest, null if there is no such entry or the manifest file does not exists.
@@ -129,6 +132,7 @@ public class Utils {
 
    /**
     * Gets the class implementation version from manifest.
+    *
     * @param clazz The class I want to obtain version of.
     * @return The class specification version from manifest, null if there is no version information present or the manifest file does not exists.
     */
@@ -146,6 +150,7 @@ public class Utils {
 
    /**
     * Gets the class specification version from manifest.
+    *
     * @param clazz The class I want to obtain version of.
     * @return The class specification version from manifest, null if there is no version information present or the manifest file does not exists.
     */
@@ -163,6 +168,7 @@ public class Utils {
 
    /**
     * Do the best to sleep for the given time. Ignores {@link InterruptedException}.
+    *
     * @param ms The number of milliseconds to sleep for.
     */
    public static void sleep(final long ms) {

--- a/microservices/src/test/java/io/silverware/microservices/BootTest.java
+++ b/microservices/src/test/java/io/silverware/microservices/BootTest.java
@@ -19,10 +19,11 @@
  */
 package io.silverware.microservices;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import io.silverware.microservices.providers.MicroserviceProvider;
 import io.silverware.microservices.util.BootUtil;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -40,7 +41,6 @@ public class BootTest {
    private static boolean wasRun = false;
    private static boolean wasInterrupted = false;
    private static final Semaphore semaphore = new Semaphore(0);
-
 
    @BeforeMethod
    public void beforeMethod() {


### PR DESCRIPTION
…leaned up the microservices project.

Hello,
this pull request follows the https://github.com/px3/SilverWare/pull/37 pull request. I did not performed the step number 3 as I have a few comments and clean up is not finished for the whole project.

Code formatting
i) Line length 400
I think this is not good as it depends on size of the user's display. Line with 400 chars will be difficult to read on small displays e.g. mine is 14" and I am not able to read such lines at all. I would set this to length 80 or 120 chars.

ii) Line wrapping
Is set to "Do not wrap" because of 400 line length. If we change line length to 80 - 120 chars, line wrapping should be like "wrap where necessary", or for some cases "wrap all elements, every element on a new line".

iii) JavadocMethod rule
I agree that every public method must have javadoc explaining what the method does. The rule is commented out within checkstyle for now.

iv) Import order
PerfCake import order defines special order for third party packages which is not possible to do in checkstyle. However, If there is no special reason for it, import order for SilverWare can be:
1. static imports
2. io.silverware
3. third party libraries (can be sorted alphabetically)
   4.java
   5.javax

Thanks for comments.
