### PR TITLE
REST integration with microservices and CDI.

### DIFF
--- a/cdi-microservice-provider/src/main/java/io/silverware/microservices/providers/cdi/internal/MicroservicesCDIExtension.java
+++ b/cdi-microservice-provider/src/main/java/io/silverware/microservices/providers/cdi/internal/MicroservicesCDIExtension.java
@@ -33,10 +33,12 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Member;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Any;
@@ -238,7 +240,8 @@ public class MicroservicesCDIExtension implements Extension {
     * @return Microservice meta-data.
     */
    private MicroserviceMetaData getMicroserviceMetaData(final String microserviceName, final Bean<?> bean) {
-      return new MicroserviceMetaData(microserviceName, bean.getBeanClass(), bean.getQualifiers());
+      return new MicroserviceMetaData(microserviceName, bean.getBeanClass(), bean.getQualifiers(), new HashSet<>(
+            Arrays.asList(bean.getBeanClass().getAnnotations())));
    }
 
    /**

--- a/http-server-microservice-provider/pom.xml
+++ b/http-server-microservice-provider/pom.xml
@@ -17,6 +17,7 @@
       <dependency>
          <groupId>io.silverware</groupId>
          <artifactId>cdi-microservice-provider</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.logging.log4j</groupId>
@@ -53,6 +54,7 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-dependency-plugin</artifactId>
+            <version>${version.maven.dependency.plugin}</version>
          </plugin>
       </plugins>
    </build>

--- a/http-server-microservice-provider/pom.xml
+++ b/http-server-microservice-provider/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <modelVersion>4.0.0</modelVersion>
    <parent>
       <groupId>io.silverware</groupId>
@@ -14,6 +15,10 @@
          <artifactId>microservices</artifactId>
       </dependency>
       <dependency>
+         <groupId>io.silverware</groupId>
+         <artifactId>cdi-microservice-provider</artifactId>
+      </dependency>
+      <dependency>
          <groupId>org.apache.logging.log4j</groupId>
          <artifactId>log4j-web</artifactId>
       </dependency>
@@ -25,13 +30,29 @@
          <groupId>io.undertow</groupId>
          <artifactId>undertow-servlet</artifactId>
       </dependency>
+      <dependency>
+         <groupId>org.jboss.resteasy</groupId>
+         <artifactId>resteasy-undertow</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.jboss.resteasy</groupId>
+         <artifactId>resteasy-jackson2-provider</artifactId>
+      </dependency>
+      <dependency>
+          <groupId>org.jboss.resteasy</groupId>
+          <artifactId>resteasy-jaxb-provider</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.assertj</groupId>
+         <artifactId>assertj-core</artifactId>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
    <build>
       <plugins>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-dependency-plugin</artifactId>
-            <version>${version.maven.dependency.plugin}</version>
          </plugin>
       </plugins>
    </build>

--- a/http-server-microservice-provider/src/main/java/io/silverware/microservices/providers/http/HttpServerMicroserviceProvider.java
+++ b/http-server-microservice-provider/src/main/java/io/silverware/microservices/providers/http/HttpServerMicroserviceProvider.java
@@ -22,8 +22,8 @@ package io.silverware.microservices.providers.http;
 import io.silverware.microservices.Context;
 import io.silverware.microservices.SilverWareException;
 import io.silverware.microservices.providers.MicroserviceProvider;
-import io.silverware.microservices.providers.cdi.CdiMicroserviceProvider;
 import io.silverware.microservices.providers.http.resteasy.SilverwareResourceFactory;
+import io.silverware.microservices.silver.CdiSilverService;
 import io.silverware.microservices.silver.HttpServerSilverService;
 import io.silverware.microservices.silver.http.ServletDescriptor;
 import io.silverware.microservices.util.Utils;
@@ -75,7 +75,8 @@ public class HttpServerMicroserviceProvider implements MicroserviceProvider, Htt
 
    @Override
    @SuppressWarnings("unchecked")
-   public void deployServlet(final String contextPath, final String deploymentName, final List<ServletDescriptor> servletDescriptors) throws SilverWareException {
+   public void deployServlet(final String contextPath, final String deploymentName,
+         final List<ServletDescriptor> servletDescriptors) throws SilverWareException {
       final DeploymentInfo servletBuilder = Servlets
             .deployment()
             .setClassLoader(this.getClass().getClassLoader())
@@ -136,11 +137,11 @@ public class HttpServerMicroserviceProvider implements MicroserviceProvider, Htt
    }
 
    /**
-    * Waits until {@link CdiMicroserviceProvider} has registered all Microservices to {@link Context}.
+    * Waits until {@link CdiSilverService} is deployed, thus all Microservices have been registered to {@link Context}.
     */
    private void waitForCDIProvider() throws InterruptedException {
-      while (this.context.getProvider(CdiMicroserviceProvider.class) == null || !((CdiMicroserviceProvider) this.context
-            .getProvider(CdiMicroserviceProvider.class)).isDeployed()) {
+      while (this.context.getProvider(CdiSilverService.class) == null || !((CdiSilverService) this.context
+            .getProvider(CdiSilverService.class)).isDeployed()) {
          Thread.sleep(200);
       }
    }

--- a/http-server-microservice-provider/src/main/java/io/silverware/microservices/providers/http/resteasy/SilverwareResourceFactory.java
+++ b/http-server-microservice-provider/src/main/java/io/silverware/microservices/providers/http/resteasy/SilverwareResourceFactory.java
@@ -1,0 +1,84 @@
+/*
+ * -----------------------------------------------------------------------\
+ * SilverWare
+ *  
+ * Copyright (C) 2010 - 2013 the original author or authors.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------/
+ */
+package io.silverware.microservices.providers.http.resteasy;
+
+import io.silverware.microservices.Context;
+import io.silverware.microservices.MicroserviceMetaData;
+
+import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.HttpResponse;
+import org.jboss.resteasy.spi.ResourceFactory;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+
+/**
+ * Silverware resource factory producing a Microservice from a context
+ * and Microservice metadata.
+ *
+ * @author Radek Koubsky (radek.koubsky@gmail.com)
+ */
+public class SilverwareResourceFactory implements ResourceFactory {
+   private final Context context;
+   private final MicroserviceMetaData microserviceMetadata;
+
+   /**
+    * Ctor.
+    *
+    * @param context Microservices context
+    * @param microserviceMetadata Microservice metadata
+    */
+   public SilverwareResourceFactory(final Context context, final MicroserviceMetaData microserviceMetadata) {
+      super();
+      this.context = context;
+      this.microserviceMetadata = microserviceMetadata;
+   }
+
+   @Override
+   public Class<?> getScannableClass() {
+      return this.microserviceMetadata.getType();
+   }
+
+   @Override
+   public void registered(final ResteasyProviderFactory factory) {
+      // TODO Auto-generated method stub
+
+   }
+
+   @Override
+   public Object createResource(final HttpRequest request, final HttpResponse response,
+         final ResteasyProviderFactory factory) {
+      /*
+       * What should follow if an empty set of microservices is returned?
+       */
+      return this.context.lookupMicroservice(this.microserviceMetadata).iterator().next();
+   }
+
+   @Override
+   public void requestFinished(final HttpRequest request, final HttpResponse response, final Object resource) {
+      // TODO Auto-generated method stub
+
+   }
+
+   @Override
+   public void unregistered() {
+      // TODO Auto-generated method stub
+
+   }
+
+}

--- a/http-server-microservice-provider/src/test/java/io/silverware/microservices/providers/http/HttpServerMicroserviceProviderRestTest.java
+++ b/http-server-microservice-provider/src/test/java/io/silverware/microservices/providers/http/HttpServerMicroserviceProviderRestTest.java
@@ -1,0 +1,303 @@
+/*
+ * -----------------------------------------------------------------------\
+ * SilverWare
+ *  
+ * Copyright (C) 2010 - 2013 the original author or authors.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------/
+ */
+package io.silverware.microservices.providers.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.silverware.microservices.annotations.Microservice;
+import io.silverware.microservices.annotations.MicroserviceReference;
+import io.silverware.microservices.providers.cdi.CdiMicroserviceProvider;
+import io.silverware.microservices.silver.HttpServerSilverService;
+import io.silverware.microservices.util.BootUtil;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author Radek Koubsky (radek.koubsky@gmail.com)
+ */
+public class HttpServerMicroserviceProviderRestTest {
+   private static final Logger log = LogManager.getLogger(HttpServerMicroserviceProviderRestTest.class);
+   private Map<String, Object> platformProperties;
+   private Client client;
+   private Thread platform;
+
+   @BeforeClass
+   public void setUpPlatforn() throws InterruptedException {
+      final BootUtil bootUtil = new BootUtil();
+      this.platformProperties = bootUtil.getContext().getProperties();
+      this.platformProperties.put(HttpServerSilverService.HTTP_SERVER_PORT, 8282);
+
+      this.platform = bootUtil.getMicroservicePlatform(
+            this.getClass().getPackage().getName(),
+            CdiMicroserviceProvider.class.getPackage().getName());
+      this.platform.start();
+
+      while (bootUtil.getContext().getProperties().get(CdiMicroserviceProvider.BEAN_MANAGER) == null) {
+         Thread.sleep(200);
+      }
+      this.client = ClientBuilder.newClient();
+   }
+
+   @AfterClass
+   public void tearDown() throws InterruptedException {
+      this.client.close();
+      this.platform.interrupt();
+      this.platform.join();
+   }
+
+   @Test
+   public void lookupMicroserviceForRESTTest() throws Exception {
+      assertThat(
+            this.client
+                  .target(baseURI(this.platformProperties) + "/helloservice/hello")
+                  .request(MediaType.TEXT_PLAIN)
+                  .get()
+                  .readEntity(String.class)).as(
+            "Rest microservice should return 'Hello from " + MicroserviceA.class.getName() + "'").isEqualTo(
+            "Hello from " + MicroserviceA.class.getName());
+   }
+
+   @Test
+   public void microserviceQueryParamsTest() throws Exception {
+      assertThat(
+            this.client
+                  .target(baseURI(this.platformProperties) + "/helloservice/test_query_params?name=Radek&age=25")
+                  .request(MediaType.TEXT_PLAIN)
+                  .get()
+                  .readEntity(String.class)).as("Rest microservice should return 'Radek;25'").isEqualTo("Radek;25");
+   }
+
+   @Test
+   public void microserviceDefaultQueryParamsTest() throws Exception {
+      assertThat(
+            this.client
+                  .target(baseURI(this.platformProperties) + "/helloservice/test_query_params")
+                  .request(MediaType.TEXT_PLAIN)
+                  .get()
+                  .readEntity(String.class)).as("Rest microservice should return 'John;25'").isEqualTo("John;21");
+   }
+
+   @Test
+   public void microservicePathParamTest() throws Exception {
+      assertThat(
+            this.client
+                  .target(baseURI(this.platformProperties) + "/helloservice/5")
+                  .request(MediaType.TEXT_PLAIN)
+                  .get()
+                  .readEntity(String.class)).as("Rest microservice should return '5' as path param.").isEqualTo("5");
+   }
+
+   @Test
+   public void microserviceJsonTest() throws Exception {
+      final Person person = new Person("John", "Collins", 30);
+      assertThat(
+            this.client
+                  .target(baseURI(this.platformProperties) + "/helloservice/test_json")
+                  .request(MediaType.APPLICATION_JSON)
+                  .post(Entity.json(person))
+                  .readEntity(Person.class)).as("Rest microservice should return:" + person).isEqualTo(person);
+   }
+
+   @Test
+   public void microserviceXmlTest() throws Exception {
+      final Person person = new Person("John", "Collins", 30);
+      assertThat(
+            this.client
+                  .target(baseURI(this.platformProperties) + "/helloservice/test_xml")
+                  .request(MediaType.APPLICATION_XML)
+                  .post(Entity.xml(person))
+                  .readEntity(Person.class)).as("Rest microservice should return:" + person).isEqualTo(person);
+   }
+
+   /**
+    * @param platformProperties
+    * @return base URI
+    */
+   private String baseURI(final Map<String, Object> platformProperties) {
+      return "http://" + platformProperties.get(HttpServerSilverService.HTTP_SERVER_ADDRESS) + ":" + platformProperties
+            .get(HttpServerSilverService.HTTP_SERVER_PORT) + platformProperties
+            .get(HttpServerSilverService.HTTP_SERVER_REST_CONTEXT_PATH) + "/" + platformProperties
+            .get(HttpServerSilverService.HTTP_SERVER_REST_SERVLET_MAPPING_PREFIX);
+   }
+
+   @Path("helloservice")
+   @Microservice
+   @Dependent
+   public static class MyRestService {
+      @Inject
+      @MicroserviceReference
+      private MicroserviceA msA;
+
+      @GET
+      @Produces(MediaType.TEXT_PLAIN)
+      @Path("hello")
+      public Response sayHello() {
+         log.info("Redirecting to " + MicroserviceA.class.getName());
+         return Response.ok(this.msA.hello()).build();
+      }
+
+      @GET
+      @Path("test_query_params")
+      @Produces(MediaType.TEXT_PLAIN)
+      public Response printQueryParams(@QueryParam("name") @DefaultValue("John") final String name,
+            @QueryParam("age") @DefaultValue("21") final int age) {
+         return Response.ok(name + ";" + age).build();
+      }
+
+      @GET
+      @Path("/{id}")
+      @Produces(MediaType.TEXT_PLAIN)
+      public Response pathParamTest(@PathParam("id") final long id) {
+         return Response.ok().entity(id).build();
+      }
+
+      @POST
+      @Path("/test_json")
+      @Produces(MediaType.APPLICATION_JSON)
+      @Consumes(MediaType.APPLICATION_JSON)
+      public Response jsonTest(final Person person) {
+         return Response.ok().entity(person).build();
+      }
+
+      @POST
+      @Path("/test_xml")
+      @Produces(MediaType.APPLICATION_XML)
+      @Consumes(MediaType.APPLICATION_XML)
+      public Response xmlTest(final Person person) {
+         return Response.ok().entity(person).build();
+      }
+
+   }
+
+   @Microservice
+   public static class MicroserviceA {
+      public String hello() {
+         return "Hello from " + this.getClass().getName();
+      };
+   }
+
+   @XmlRootElement
+   public static class Person {
+      @XmlElement(name = "name")
+      private String name;
+      @XmlElement(name = "surname")
+      private String surname;
+      @XmlElement(name = "age")
+      private int age;
+
+      public Person() {
+
+      }
+
+      /**
+       * Ctor.
+       *
+       * @param name
+       * @param surname
+       * @param age
+       */
+      @JsonCreator
+      public Person(@JsonProperty("name") final String name, @JsonProperty("surname") final String surname,
+            @JsonProperty("age") final int age) {
+         super();
+         this.name = name;
+         this.surname = surname;
+         this.age = age;
+      }
+
+      public String getName() {
+         return this.name;
+      }
+
+      public String getSurname() {
+         return this.surname;
+      }
+
+      public int getAge() {
+         return this.age;
+      }
+
+      @Override
+      public int hashCode() {
+         final int prime = 31;
+         int result = 1;
+         result = prime * result + this.age;
+         result = prime * result + ((this.name == null) ? 0 : this.name.hashCode());
+         result = prime * result + ((this.surname == null) ? 0 : this.surname.hashCode());
+         return result;
+      }
+
+      @Override
+      public boolean equals(final Object obj) {
+         if (this == obj)
+            return true;
+         if (obj == null)
+            return false;
+         if (getClass() != obj.getClass())
+            return false;
+         final Person other = (Person) obj;
+         if (this.age != other.age)
+            return false;
+         if (this.name == null) {
+            if (other.name != null)
+               return false;
+         } else if (!this.name.equals(other.name))
+            return false;
+         if (this.surname == null) {
+            if (other.surname != null)
+               return false;
+         } else if (!this.surname.equals(other.surname))
+            return false;
+         return true;
+      }
+
+      @Override
+      public String toString() {
+         return String.format("Person [name=%s, surname=%s, age=%s]", this.name, this.surname, this.age);
+      }
+   }
+}

--- a/http-server-microservice-provider/src/test/java/io/silverware/microservices/providers/http/HttpServerMicroserviceProviderTest.java
+++ b/http-server-microservice-provider/src/test/java/io/silverware/microservices/providers/http/HttpServerMicroserviceProviderTest.java
@@ -23,6 +23,9 @@ import io.silverware.microservices.silver.HttpServerSilverService;
 import io.silverware.microservices.silver.http.ServletDescriptor;
 import io.silverware.microservices.util.BootUtil;
 import io.silverware.microservices.util.Utils;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -31,6 +34,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Semaphore;
+
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -40,6 +44,7 @@ import javax.servlet.http.HttpServletResponse;
  * @author <a href="mailto:marvenec@gmail.com">Martin Večeřa</a>
  */
 public class HttpServerMicroserviceProviderTest {
+   private static final Logger log = LogManager.getLogger(HttpServerMicroserviceProviderTest.class);
 
    private static final Semaphore semaphore = new Semaphore(0);
 
@@ -48,13 +53,10 @@ public class HttpServerMicroserviceProviderTest {
       final BootUtil bootUtil = new BootUtil();
       final Map<String, Object> platformProperties = bootUtil.getContext().getProperties();
       platformProperties.put(HttpServerSilverService.HTTP_SERVER_PORT, 8282);
-
       final Thread platform = bootUtil.getMicroservicePlatform(this.getClass().getPackage().getName());
       platform.start();
-
       final Properties servletProperties = new Properties();
       servletProperties.setProperty("greeting", "Mr. Wolf");
-
       int tries = 0;
       HttpServerSilverService http = null;
       while (http == null && tries < 600) {
@@ -62,15 +64,16 @@ public class HttpServerMicroserviceProviderTest {
          Thread.sleep(100);
          tries++;
       }
-
       Assert.assertNotNull(http, "Unable to obtain Http Server Silverservice.");
-
-      http.deployServlet("test", "", Collections.singletonList(new ServletDescriptor("test", HttpTestServlet.class, "/", servletProperties)));
+      http.deployServlet(
+            "test",
+            "",
+            Collections.singletonList(new ServletDescriptor("test", HttpTestServlet.class, "/", servletProperties)));
 
       Thread.sleep(500);
-
-      Assert.assertEquals(Utils.readFromUrl("http://" + platformProperties.get(HttpServerSilverService.HTTP_SERVER_ADDRESS) + ":" +
-            platformProperties.get(HttpServerSilverService.HTTP_SERVER_PORT) + "/test/"), "Hello Mr. Wolf");
+      Assert.assertEquals(Utils.readFromUrl("http://" + platformProperties
+            .get(HttpServerSilverService.HTTP_SERVER_ADDRESS) + ":" + platformProperties
+            .get(HttpServerSilverService.HTTP_SERVER_PORT) + "/test/"), "Hello Mr. Wolf");
 
       platform.interrupt();
       platform.join();
@@ -79,7 +82,8 @@ public class HttpServerMicroserviceProviderTest {
    public static class HttpTestServlet extends HttpServlet {
 
       @Override
-      protected void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
+      protected void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException,
+            IOException {
          resp.getWriter().append("Hello " + getInitParameter("greeting"));
       }
    }

--- a/http-server-microservice-provider/src/test/resources/META-INF/beans.xml
+++ b/http-server-microservice-provider/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+</beans>

--- a/microservices-bom/pom.xml
+++ b/microservices-bom/pom.xml
@@ -72,6 +72,8 @@
       <version.jsonio>4.3.0</version.jsonio>
       <version.beanutils>1.9.2</version.beanutils>
       <version.drools>6.3.0.Final</version.drools>
+      <version.org.assertj>3.5.2</version.org.assertj>
+      <version.org.jboss.resteasy>3.0.17.Final</version.org.jboss.resteasy>
       <java.level>1.8</java.level>
    </properties>
    <dependencyManagement>
@@ -313,6 +315,27 @@
             <groupId>org.drools</groupId>
             <artifactId>drools-compiler</artifactId>
             <version>${version.drools}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-undertow</artifactId>
+            <version>${version.org.jboss.resteasy}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jackson2-provider</artifactId>
+            <version>${version.org.jboss.resteasy}</version>
+         </dependency>
+         <dependency>
+             <groupId>org.jboss.resteasy</groupId>
+             <artifactId>resteasy-jaxb-provider</artifactId>
+             <version>${version.org.jboss.resteasy}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${version.org.assertj}</version>
+            <scope>test</scope>
          </dependency>
       </dependencies>
    </dependencyManagement>

--- a/microservices/src/main/java/io/silverware/microservices/silver/HttpServerSilverService.java
+++ b/microservices/src/main/java/io/silverware/microservices/silver/HttpServerSilverService.java
@@ -48,6 +48,16 @@ public interface HttpServerSilverService extends SilverService {
    String HTTP_SERVER_ADDRESS = "silverware.http.address";
 
    /**
+    * Context path to which REST requests are routed
+    * */
+   String HTTP_SERVER_REST_CONTEXT_PATH = "silverware.http.rest.context.path";
+
+   /**
+    * Mapping of the base REST Servlet
+    * */
+   String HTTP_SERVER_REST_SERVLET_MAPPING_PREFIX = "silverware.http.rest.servlet.mapping.prefix";
+
+   /**
     * Deploys a servlet on the HTTP server.
     *
     * @param contextPath Context path where the servlet should be bound.


### PR DESCRIPTION
This is the initial implementation of #36 
Microservices (annotated with @Path) can be reached via REST provided by the RESTEasy implementation, supported features:
- JAX-RS elements (path, query params etc.)
- JAXB XML provider
- JSON (jackson) provider

The following steps will be implemented in next pull requests:
1) Remove old REST functionality
    a) remove RestInterface class, Gateway annotation etc.
    b) refactor code using old REST API (client provider, align demos with the new REST API etc.)
2) Add support for SSL
