### PR TITLE
Change bean-discovery-mode from 'all' to 'annotated'

### DIFF
--- a/cdi-microservice-provider/pom.xml
+++ b/cdi-microservice-provider/pom.xml
@@ -41,6 +41,11 @@
          <groupId>commons-beanutils</groupId>
          <artifactId>commons-beanutils</artifactId>
       </dependency>
+      <dependency>
+         <groupId>org.jboss</groupId>
+         <artifactId>jandex</artifactId>
+         <scope>runtime</scope>
+      </dependency>
    </dependencies>
    <build>
       <plugins>

--- a/cdi-microservice-provider/src/main/resources/META-INF/beans.xml
+++ b/cdi-microservice-provider/src/main/resources/META-INF/beans.xml
@@ -1,4 +1,4 @@
-<beans>
+<beans bean-discovery-mode="annotated">
    <!--alternatives>
       <class>io.silverware.microservices.providers.cdi.CdiMicroserviceProviderAlternativesTest$AlternateAlternativesMicroBean</class>
    </alternatives-->

--- a/microservices-bom/pom.xml
+++ b/microservices-bom/pom.xml
@@ -74,6 +74,7 @@
       <version.drools>6.3.0.Final</version.drools>
       <version.org.assertj>3.5.2</version.org.assertj>
       <version.org.jboss.resteasy>3.0.17.Final</version.org.jboss.resteasy>
+      <version.jandex>2.0.3.Final</version.jandex>
       <java.level>1.8</java.level>
    </properties>
    <dependencyManagement>
@@ -336,6 +337,11 @@
             <artifactId>assertj-core</artifactId>
             <version>${version.org.assertj}</version>
             <scope>test</scope>
+         </dependency>
+         <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jandex</artifactId>
+            <version>${version.jandex}</version>
          </dependency>
       </dependencies>
    </dependencyManagement>


### PR DESCRIPTION
I have changed CDI bean-discovery-mode from 'all' to 'annotated'. This prevents classes with no-argument constructor from becoming a managed bean unless they have a bean defining annotation (see [Weld documentation](http://docs.jboss.org/weld/reference/latest-master/en-US/html/environments.html#_implicit_bean_archive_support_2) for more details). There are some examples of such classes in `cdi-microservice-provider` module which were accidentally managed by container.
