### PR TITLE
Clustering and test fixes.

### DIFF
--- a/cdi-microservice-provider/src/main/java/io/silverware/microservices/providers/cdi/internal/MicroserviceProxy.java
+++ b/cdi-microservice-provider/src/main/java/io/silverware/microservices/providers/cdi/internal/MicroserviceProxy.java
@@ -21,7 +21,6 @@ package io.silverware.microservices.providers.cdi.internal;
 
 import io.silverware.microservices.MicroserviceMetaData;
 import io.silverware.microservices.annotations.MicroserviceReference;
-import io.silverware.microservices.silver.cluster.ServiceHandle;
 import io.silverware.microservices.silver.services.LookupStrategy;
 import io.silverware.microservices.silver.services.LookupStrategyFactory;
 import javassist.util.proxy.MethodHandler;
@@ -41,9 +40,9 @@ public class MicroserviceProxy implements MethodHandler {
 
    private static final Logger log = LogManager.getLogger(MicroserviceProxy.class);
 
-   private MicroserviceProxyBean parentBean;
+   private final MicroserviceProxyBean parentBean;
 
-   private LookupStrategy lookupStrategy;
+   private final LookupStrategy lookupStrategy;
 
    private MicroserviceProxy(final MicroserviceProxyBean parentBean) throws Exception {
       this.parentBean = parentBean;
@@ -75,7 +74,7 @@ public class MicroserviceProxy implements MethodHandler {
       try {
          ProxyFactory factory = new ProxyFactory();
          if (parentBean.getServiceInterface().isInterface()) {
-            factory.setInterfaces(new Class[] { parentBean.getServiceInterface() });
+            factory.setInterfaces(new Class[]{parentBean.getServiceInterface()});
          } else {
             factory.setSuperclass(parentBean.getServiceInterface());
          }
@@ -107,12 +106,6 @@ public class MicroserviceProxy implements MethodHandler {
       }
 
       Object service = getService();
-      // TODO: 9/8/16 FIXME just workaround for a remote invocation (context is not necessary)
-      if (service instanceof ServiceHandle) {
-         return ((ServiceHandle) service).invoke(null, thisMethod.getName(), thisMethod.getParameterTypes(), args);
-      } else {
-
-         return thisMethod.invoke(service, args);
-      }
+      return thisMethod.invoke(service, args);
    }
 }

--- a/cdi-microservice-provider/src/test/java/io/silverware/microservices/providers/cdi/CdiMicroserviceProviderGatewayTest.java
+++ b/cdi-microservice-provider/src/test/java/io/silverware/microservices/providers/cdi/CdiMicroserviceProviderGatewayTest.java
@@ -19,6 +19,14 @@
  */
 package io.silverware.microservices.providers.cdi;
 
+import io.silverware.microservices.annotations.Gateway;
+import io.silverware.microservices.annotations.Microservice;
+import io.silverware.microservices.annotations.ParamName;
+import io.silverware.microservices.util.BootUtil;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.testng.Assert;
@@ -28,16 +36,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
-import javax.enterprise.inject.spi.BeanManager;
-
-import io.silverware.microservices.annotations.Gateway;
-import io.silverware.microservices.annotations.Microservice;
-import io.silverware.microservices.annotations.ParamName;
-import io.silverware.microservices.util.BootUtil;
-import io.vertx.core.Vertx;
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 
 /**
  * @author <a href="mailto:marvenec@gmail.com">Martin Večeřa</a>
@@ -55,7 +53,7 @@ public class CdiMicroserviceProviderGatewayTest {
       platform.start();
 
       CdiMicroserviceProviderTestUtil.waitForBeanManager(bootUtil);
-
+      Thread.sleep(100);
       final List<String> checksPassed = new ArrayList<>();
 
       Vertx vertx = Vertx.vertx();

--- a/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/ClusterMicroserviceProvider.java
+++ b/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/ClusterMicroserviceProvider.java
@@ -136,7 +136,7 @@ public class ClusterMicroserviceProvider implements MicroserviceProvider, Cluste
                        }
                        Set<ServiceHandle> remoteServiceHandles = result.stream()
                                .filter(rsp -> rsp.wasReceived() && rsp.getValue().getResult().canBeUsed())
-                               .map((rsp) -> new RemoteServiceHandle(rsp.getSender(), rsp.getValue().getHandle(), sender))
+                               .map((rsp) -> new RemoteServiceHandle(rsp.getSender(), rsp.getValue().getHandle(), sender, metaData))
                                .collect(Collectors.toSet());
                        // this is to save jgroups traffic for a given metadata
                        addressesForMetadata.addAll(responseRspList.values().stream().map(Rsp::getSender).collect(Collectors.toSet()));

--- a/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/RemoteServiceHandle.java
+++ b/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/RemoteServiceHandle.java
@@ -49,17 +49,7 @@ public class RemoteServiceHandle implements ServiceHandle {
       return address.toString();
    }
 
-   /**
-    * Method overload which would retrieve classes and call <code>invoke(Context context, String method, Class[] paramTypes, Object[] params) throws Exception</code>
-    * and
-    *
-    * @param context    is ignored for this invocation
-    * @param method     name of the method to be called
-    * @param params     parameters of method called
-    * @param paramTypes classes of parameters
-    * @return result of call
-    * @throws Exception if exception has occured
-    */
+
    @Override
    public Object invoke(Context context, String method, Class[] paramTypes, Object[] params) throws Exception {
       Invocation invocation = new Invocation(handle, method, paramTypes, params);
@@ -68,29 +58,6 @@ public class RemoteServiceHandle implements ServiceHandle {
 
    }
 
-   /**
-    * Method overload which would retrieve classes and call <code>invoke(Context context, String method, Class[] paramTypes, Object[] params) throws Exception</code>
-    * and
-    *
-    * @param context is ignored for this invocation
-    * @param method  name of the method to be called
-    * @param params  parameters of method called
-    * @return result of call
-    * @throws Exception if exception has occured
-    */
-   @Override
-   public Object invoke(Context context, String method, Object[] params) throws Exception {
-      Class[] paramTypes = new Class[params.length];
-      for (int i = 0; i < params.length; i++) {
-         // TODO: 9/9/16 primitive types or null is not possible to resolve
-         if (params[i] != null) {
-            paramTypes[i] = params[i].getClass();
-         }
-
-      }
-      return invoke(context, method, paramTypes, params);
-
-   }
 
    @Override
    public boolean equals(Object o) {

--- a/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/HttpServiceProxy.java
+++ b/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/HttpServiceProxy.java
@@ -64,6 +64,6 @@ public class HttpServiceProxy implements MethodHandler {
 
    @Override
    public Object invoke(final Object o, final Method method, final Method method1, final Object[] objects) throws Throwable {
-      return serviceHandle.invoke(context, method.getName(), objects);
+      return serviceHandle.invoke(context, method.getName(),method.getParameterTypes(), objects);
    }
 }

--- a/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/JgroupsMessageReceiver.java
+++ b/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/JgroupsMessageReceiver.java
@@ -20,8 +20,6 @@
 package io.silverware.microservices.providers.cluster.internal;
 
 import io.silverware.microservices.providers.cluster.internal.exception.SilverWareClusteringException;
-import static io.silverware.microservices.providers.cluster.internal.exception.SilverWareClusteringException.SilverWareClusteringError.RECIPIENT_SAME_AS_SENDER;
-import static io.silverware.microservices.providers.cluster.internal.exception.SilverWareClusteringException.SilverWareClusteringError.UNEXPECTED_CONTENT;
 import io.silverware.microservices.providers.cluster.internal.message.responder.Responder;
 import io.silverware.microservices.silver.cluster.RemoteServiceHandlesStore;
 import org.apache.logging.log4j.LogManager;
@@ -37,6 +35,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static io.silverware.microservices.providers.cluster.internal.exception.SilverWareClusteringException.SilverWareClusteringError.RECIPIENT_SAME_AS_SENDER;
+import static io.silverware.microservices.providers.cluster.internal.exception.SilverWareClusteringException.SilverWareClusteringError.UNEXPECTED_CONTENT;
+
 /**
  * Class responsible for retrieving messages
  *
@@ -46,7 +47,7 @@ public class JgroupsMessageReceiver extends ReceiverAdapter implements RequestHa
 
    private static final Logger log = LogManager.getLogger(JgroupsMessageReceiver.class);
    private Map<Class, Responder> responders = new HashMap<>();
-   private RemoteServiceHandlesStore store;
+   private final RemoteServiceHandlesStore store;
    private Address myAddress;
 
    public JgroupsMessageReceiver(Map<Class, Responder> responders, RemoteServiceHandlesStore store) {
@@ -70,14 +71,11 @@ public class JgroupsMessageReceiver extends ReceiverAdapter implements RequestHa
 
    @Override
    public void receive(final Message msg) {
-      log.error("This method should not be called!");
-      Object content = msg.getObject();
-      Responder responder = this.responders.get(content.getClass());
-      if (responder != null) {
-         responder.processMessage(msg);
-      } else {
-         log.error("Unexpected content type : {} calling toString:  {} ", content.getClass(), content);
-         throw new SilverWareClusteringException(UNEXPECTED_CONTENT, content.getClass().toString());
+      log.error("This method is for user option to send messages!");
+      try {
+         handle(msg);
+      } catch (Exception e) {
+         log.error("Error processing message", e);
       }
    }
 
@@ -85,9 +83,7 @@ public class JgroupsMessageReceiver extends ReceiverAdapter implements RequestHa
    public void viewAccepted(final View view) {
       Set<String> addresses = view.getMembers().stream().map(Address::toString).collect(Collectors.toSet());
       store.keepHandlesFor(addresses);
-      if (log.isDebugEnabled()) {
-         log.debug("Cluster view changed: " + view);
-      }
+      log.info("Cluster view change: " + view);
    }
 
 

--- a/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/JgroupsMessageReceiver.java
+++ b/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/JgroupsMessageReceiver.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static io.silverware.microservices.providers.cluster.internal.exception.SilverWareClusteringException.SilverWareClusteringError.PROCESSING_ERROR;
 import static io.silverware.microservices.providers.cluster.internal.exception.SilverWareClusteringException.SilverWareClusteringError.RECIPIENT_SAME_AS_SENDER;
 import static io.silverware.microservices.providers.cluster.internal.exception.SilverWareClusteringException.SilverWareClusteringError.UNEXPECTED_CONTENT;
 
@@ -75,7 +76,7 @@ public class JgroupsMessageReceiver extends ReceiverAdapter implements RequestHa
       try {
          handle(msg);
       } catch (Exception e) {
-         log.error("Error processing message", e);
+         throw new SilverWareClusteringException(PROCESSING_ERROR, e);
       }
    }
 
@@ -89,7 +90,7 @@ public class JgroupsMessageReceiver extends ReceiverAdapter implements RequestHa
 
    @Override
    public Object handle(Message msg) throws Exception {
-      if (msg.getSrc().equals(myAddress)) {
+      if (msg.getSrc() != null && msg.getSrc().equals(myAddress)) {
          log.error("Skipping message sent from this node.");
          throw new SilverWareClusteringException(RECIPIENT_SAME_AS_SENDER);
       }

--- a/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/JgroupsMessageSender.java
+++ b/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/JgroupsMessageSender.java
@@ -48,11 +48,11 @@ public class JgroupsMessageSender {
    private static final Logger log = LogManager.getLogger(JgroupsMessageSender.class);
 
 
-   private static RequestOptions SYNC_OPTIONS = RequestOptions.SYNC();
-   private static RequestOptions ASYNC_OPTIONS = RequestOptions.ASYNC();
+   private static final RequestOptions SYNC_OPTIONS = RequestOptions.SYNC();
+   private static final RequestOptions ASYNC_OPTIONS = RequestOptions.ASYNC();
 
 
-   private MessageDispatcher dispatcher;
+   private final MessageDispatcher dispatcher;
    private Set<Address> filteredAdresses;
 
    public JgroupsMessageSender(MessageDispatcher dispatcher) {
@@ -93,7 +93,9 @@ public class JgroupsMessageSender {
       if (!othertMembersAdresses.isEmpty()) {
          this.dispatcher.castMessageWithFuture(othertMembersAdresses, new Message(null, content), SYNC_OPTIONS, listener);
       } else {
-         log.debug("No message sent.");
+         if (log.isDebugEnabled()) {
+            log.debug("No message sent.");
+         }
       }
    }
 

--- a/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/exception/SilverWareClusteringException.java
+++ b/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/exception/SilverWareClusteringException.java
@@ -31,7 +31,7 @@ public class SilverWareClusteringException extends RuntimeException {
     * Errors that can possibly happen in clustering
     */
    public enum SilverWareClusteringError {
-      JGROUPS_ERROR, UNEXPECTED_CONTENT, INVOCATION_EXCEPTION, RECIPIENT_SAME_AS_SENDER, MULTIPLE_IMPLEMENTATIONS_FOUND
+      JGROUPS_ERROR, UNEXPECTED_CONTENT, INVOCATION_EXCEPTION, RECIPIENT_SAME_AS_SENDER, MULTIPLE_IMPLEMENTATIONS_FOUND, INITIALIZATION_ERROR
 
    }
 

--- a/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/exception/SilverWareClusteringException.java
+++ b/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/exception/SilverWareClusteringException.java
@@ -31,7 +31,13 @@ public class SilverWareClusteringException extends RuntimeException {
     * Errors that can possibly happen in clustering
     */
    public enum SilverWareClusteringError {
-      JGROUPS_ERROR, UNEXPECTED_CONTENT, INVOCATION_EXCEPTION, RECIPIENT_SAME_AS_SENDER, MULTIPLE_IMPLEMENTATIONS_FOUND, INITIALIZATION_ERROR
+      JGROUPS_ERROR,
+      UNEXPECTED_CONTENT,
+      INVOCATION_EXCEPTION,
+      RECIPIENT_SAME_AS_SENDER,
+      MULTIPLE_IMPLEMENTATIONS_FOUND,
+      INITIALIZATION_ERROR,
+      PROCESSING_ERROR
 
    }
 

--- a/cluster-microservice-provider/src/test/java/io/silverware/microservices/providers/cluster/internal/RemoteServiceHandleStoreTest.java
+++ b/cluster-microservice-provider/src/test/java/io/silverware/microservices/providers/cluster/internal/RemoteServiceHandleStoreTest.java
@@ -24,13 +24,14 @@ import io.silverware.microservices.providers.cluster.Util;
 import io.silverware.microservices.silver.cluster.LocalServiceHandle;
 import io.silverware.microservices.silver.cluster.RemoteServiceHandlesStore;
 import io.silverware.microservices.silver.cluster.ServiceHandle;
-import static org.assertj.core.api.Assertions.assertThat;
 import org.testng.annotations.Test;
 
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Basic Unit tests for remote handles store
@@ -50,7 +51,7 @@ public class RemoteServiceHandleStoreTest {
       RemoteServiceHandlesStore store = new RemoteServiceHandlesStore();
       store.addHandle(META_DATA, SERVICE_HANDLE);
       Set<Object> services = store.getServices(META_DATA);
-      assertThat(services).containsOnly(SERVICE_HANDLE);
+      assertThat(services).containsOnly(SERVICE_HANDLE.getProxy());
    }
 
    @Test
@@ -61,7 +62,7 @@ public class RemoteServiceHandleStoreTest {
       store.keepHandlesFor(Util.createSetFrom("host"));
 
       Set<Object> services = store.getServices(META_DATA);
-      assertThat(services).containsOnly(SERVICE_HANDLE);
+      assertThat(services).containsOnly(SERVICE_HANDLE.getProxy());
    }
 
    @Test

--- a/http-server-microservice-provider/src/test/java/io/silverware/microservices/providers/http/SSLTest.java
+++ b/http-server-microservice-provider/src/test/java/io/silverware/microservices/providers/http/SSLTest.java
@@ -1,15 +1,10 @@
 package io.silverware.microservices.providers.http;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.silverware.microservices.annotations.Microservice;
 import io.silverware.microservices.providers.cdi.CdiMicroserviceProvider;
 import io.silverware.microservices.silver.HttpServerSilverService;
 import io.silverware.microservices.util.BootUtil;
-
 import org.testng.annotations.Test;
-
-import java.util.Map;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -18,6 +13,12 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SSLTest {
    private static final String CLIENT_KEY_STORE = "silverware-client.keystore";
@@ -32,8 +33,8 @@ public class SSLTest {
       platformProperties.put(HttpServerSilverService.HTTP_SERVER_SSL_ENABLED, "true");
 
       final Thread platform = bootUtil.getMicroservicePlatform(
-            this.getClass().getPackage().getName(),
-            CdiMicroserviceProvider.class.getPackage().getName());
+              this.getClass().getPackage().getName(),
+              CdiMicroserviceProvider.class.getPackage().getName());
       platform.start();
 
       while (bootUtil.getContext().getProperties().get(CdiMicroserviceProvider.BEAN_MANAGER) == null) {
@@ -41,46 +42,37 @@ public class SSLTest {
       }
 
       final Client client = ClientBuilder
-            .newBuilder()
-            .sslContext(
-                  new SSLContextFactory(CLIENT_KEY_STORE, STORE_PASSWORD, CLIENT_TRUST_STORE, STORE_PASSWORD)
-                        .createSSLContext())
-            .build();
-
-      assertThat(client
-            .target(new SilverWareURI(platformProperties).httpsREST() + "/sslservice/hello")
-            .request(MediaType.TEXT_PLAIN)
-            .get()
-            .readEntity(String.class))
-                  .as("Rest microservice should return 'Hello from SSL.")
-                  .isEqualTo("Hello from SSL.");
-      client.close();
-      platform.interrupt();
-      platform.join();
+              .newBuilder()
+              .sslContext(
+                      new SSLContextFactory(CLIENT_KEY_STORE, STORE_PASSWORD, CLIENT_TRUST_STORE, STORE_PASSWORD)
+                              .createSSLContext())
+              .build();
+      verifyResult(platformProperties, platform, client);
    }
 
    @Test
    public void sslConfigurationAbsolutePathTest() throws Exception {
       final BootUtil bootUtil = new BootUtil();
       final Map<String, Object> platformProperties = bootUtil.getContext().getProperties();
+
       platformProperties.put(HttpServerSilverService.HTTP_SERVER_PORT, 8282);
       platformProperties.put(HttpServerSilverService.HTTP_SERVER_SSL_ENABLED, "true");
       platformProperties.put(
-            HttpServerSilverService.HTTP_SERVER_KEY_STORE,
-            getClass().getResource("/" + HttpServerSilverService.DEFAULT_SSL_KEYSTORE).getPath());
+              HttpServerSilverService.HTTP_SERVER_KEY_STORE,
+              getCorrectPaht("/" + HttpServerSilverService.DEFAULT_SSL_KEYSTORE));
       platformProperties.put(
-            HttpServerSilverService.HTTP_SERVER_KEY_STORE_PASSWORD,
-            HttpServerSilverService.DEFAULT_SSL_STORE_PASSWORD);
+              HttpServerSilverService.HTTP_SERVER_KEY_STORE_PASSWORD,
+              HttpServerSilverService.DEFAULT_SSL_STORE_PASSWORD);
       platformProperties.put(
-            HttpServerSilverService.HTTP_SERVER_TRUST_STORE,
-            getClass().getResource("/" + HttpServerSilverService.DEFAULT_SSL_TRUSTSTORE).getPath());
+              HttpServerSilverService.HTTP_SERVER_TRUST_STORE,
+              getCorrectPaht("/" + HttpServerSilverService.DEFAULT_SSL_TRUSTSTORE));
       platformProperties.put(
-            HttpServerSilverService.HTTP_SERVER_TRUST_STORE_PASSWORD,
-            HttpServerSilverService.DEFAULT_SSL_STORE_PASSWORD);
+              HttpServerSilverService.HTTP_SERVER_TRUST_STORE_PASSWORD,
+              HttpServerSilverService.DEFAULT_SSL_STORE_PASSWORD);
 
       final Thread platform = bootUtil.getMicroservicePlatform(
-            this.getClass().getPackage().getName(),
-            CdiMicroserviceProvider.class.getPackage().getName());
+              this.getClass().getPackage().getName(),
+              CdiMicroserviceProvider.class.getPackage().getName());
       platform.start();
 
       while (bootUtil.getContext().getProperties().get(CdiMicroserviceProvider.BEAN_MANAGER) == null) {
@@ -88,22 +80,18 @@ public class SSLTest {
       }
 
       final Client client = ClientBuilder
-            .newBuilder()
-            .sslContext(
-                  new SSLContextFactory(CLIENT_KEY_STORE, STORE_PASSWORD, CLIENT_TRUST_STORE, STORE_PASSWORD)
-                        .createSSLContext())
-            .build();
+              .newBuilder()
+              .sslContext(
+                      new SSLContextFactory(CLIENT_KEY_STORE, STORE_PASSWORD, CLIENT_TRUST_STORE, STORE_PASSWORD)
+                              .createSSLContext())
+              .build();
+      verifyResult(platformProperties, platform, client);
+   }
 
-      assertThat(client
-            .target(new SilverWareURI(platformProperties).httpsREST() + "/sslservice/hello")
-            .request(MediaType.TEXT_PLAIN)
-            .get()
-            .readEntity(String.class))
-                  .as("Rest microservice should return 'Hello from SSL.")
-                  .isEqualTo("Hello from SSL.");
-      client.close();
-      platform.interrupt();
-      platform.join();
+
+   String getCorrectPaht(String path) throws URISyntaxException {
+      URI uri = getClass().getResource(path).toURI();
+      return new File(uri).getAbsolutePath();
    }
 
    @Test
@@ -113,19 +101,19 @@ public class SSLTest {
       platformProperties.put(HttpServerSilverService.HTTP_SERVER_PORT, 8282);
       platformProperties.put(HttpServerSilverService.HTTP_SERVER_SSL_ENABLED, "true");
       platformProperties
-            .put(HttpServerSilverService.HTTP_SERVER_KEY_STORE, HttpServerSilverService.DEFAULT_SSL_KEYSTORE);
+              .put(HttpServerSilverService.HTTP_SERVER_KEY_STORE, HttpServerSilverService.DEFAULT_SSL_KEYSTORE);
       platformProperties.put(
-            HttpServerSilverService.HTTP_SERVER_KEY_STORE_PASSWORD,
-            HttpServerSilverService.DEFAULT_SSL_STORE_PASSWORD);
+              HttpServerSilverService.HTTP_SERVER_KEY_STORE_PASSWORD,
+              HttpServerSilverService.DEFAULT_SSL_STORE_PASSWORD);
       platformProperties
-            .put(HttpServerSilverService.HTTP_SERVER_TRUST_STORE, HttpServerSilverService.DEFAULT_SSL_TRUSTSTORE);
+              .put(HttpServerSilverService.HTTP_SERVER_TRUST_STORE, HttpServerSilverService.DEFAULT_SSL_TRUSTSTORE);
       platformProperties.put(
-            HttpServerSilverService.HTTP_SERVER_TRUST_STORE_PASSWORD,
-            HttpServerSilverService.DEFAULT_SSL_STORE_PASSWORD);
+              HttpServerSilverService.HTTP_SERVER_TRUST_STORE_PASSWORD,
+              HttpServerSilverService.DEFAULT_SSL_STORE_PASSWORD);
 
       final Thread platform = bootUtil.getMicroservicePlatform(
-            this.getClass().getPackage().getName(),
-            CdiMicroserviceProvider.class.getPackage().getName());
+              this.getClass().getPackage().getName(),
+              CdiMicroserviceProvider.class.getPackage().getName());
       platform.start();
 
       while (bootUtil.getContext().getProperties().get(CdiMicroserviceProvider.BEAN_MANAGER) == null) {
@@ -133,22 +121,30 @@ public class SSLTest {
       }
 
       final Client client = ClientBuilder
-            .newBuilder()
-            .sslContext(
-                  new SSLContextFactory(CLIENT_KEY_STORE, STORE_PASSWORD, CLIENT_TRUST_STORE, STORE_PASSWORD)
-                        .createSSLContext())
-            .build();
+              .newBuilder()
+              .sslContext(
+                      new SSLContextFactory(CLIENT_KEY_STORE, STORE_PASSWORD, CLIENT_TRUST_STORE, STORE_PASSWORD)
+                              .createSSLContext())
+              .build();
+      verifyResult(platformProperties, platform, client);
+   }
 
-      assertThat(client
-            .target(new SilverWareURI(platformProperties).httpsREST() + "/sslservice/hello")
-            .request(MediaType.TEXT_PLAIN)
-            .get()
-            .readEntity(String.class))
-                  .as("Rest microservice should return 'Hello from SSL.")
-                  .isEqualTo("Hello from SSL.");
-      client.close();
-      platform.interrupt();
-      platform.join();
+
+   private void verifyResult(Map<String, Object> platformProperties, Thread platform, Client client) throws InterruptedException {
+      try {
+         Thread.sleep(100);
+         assertThat(client
+                 .target(new SilverWareURI(platformProperties).httpsREST() + "/sslservice/hello")
+                 .request(MediaType.TEXT_PLAIN)
+                 .get()
+                 .readEntity(String.class))
+                 .as("Rest microservice should return 'Hello from SSL.")
+                 .isEqualTo("Hello from SSL.");
+      } finally {
+         client.close();
+         platform.interrupt();
+         platform.join(0);
+      }
    }
 
    @Path("sslservice")

--- a/microservices/src/main/java/io/silverware/microservices/Context.java
+++ b/microservices/src/main/java/io/silverware/microservices/Context.java
@@ -84,7 +84,7 @@ public class Context {
    /**
     * Handles created for incoming service queries.
     */
-   private List<LocalServiceHandle> inboundHandles = new ArrayList<>();
+   private final List<LocalServiceHandle> inboundHandles = new ArrayList<>();
 
 
    /**
@@ -206,7 +206,7 @@ public class Context {
    public List<LocalServiceHandle> assureHandles(final MicroserviceMetaData metaData) {
       List<LocalServiceHandle> result = inboundHandles.stream().filter(serviceHandle -> serviceHandle.getQuery().equals(metaData)).collect(Collectors.toList());
       Set<Object> microservices = lookupLocalMicroservice(metaData);
-      Set<Object> haveHandles = result.stream().map(LocalServiceHandle::getService).collect(Collectors.toSet());
+      Set<Object> haveHandles = result.stream().map(LocalServiceHandle::getProxy).collect(Collectors.toSet());
       microservices.removeAll(haveHandles);
 
       microservices.forEach(microservice -> {

--- a/microservices/src/main/java/io/silverware/microservices/silver/ClusterSilverService.java
+++ b/microservices/src/main/java/io/silverware/microservices/silver/ClusterSilverService.java
@@ -37,4 +37,9 @@ public interface ClusterSilverService extends ProvidingSilverService {
     */
    String CLUSTER_CONFIGURATION = "silverware.cluster.configuration";
 
+   /**
+    * Timeout in milliseconds for lookup in a cluster.
+    */
+   String CLUSTER_LOOKUP_TIMEOUT = "silverware.cluster.lookup.timeout";
+
 }

--- a/microservices/src/main/java/io/silverware/microservices/silver/cluster/Invocation.java
+++ b/microservices/src/main/java/io/silverware/microservices/silver/cluster/Invocation.java
@@ -36,7 +36,7 @@ import java.util.Arrays;
  */
 public class Invocation implements Serializable {
 
-   private static Logger log = LogManager.getLogger(Invocation.class);
+   private static final Logger log = LogManager.getLogger(Invocation.class);
 
    private final int handle;
 
@@ -127,8 +127,8 @@ public class Invocation implements Serializable {
          throw new SilverWareException(String.format("Handle no. %d. No such handle found.", getHandle()));
       }
 
-      final Method method = serviceHandle.getService().getClass().getDeclaredMethod(getMethod(), paramTypes);
-      return method.invoke(serviceHandle.getService(), params);
+      final Method method = serviceHandle.getProxy().getClass().getDeclaredMethod(getMethod(), paramTypes);
+      return method.invoke(serviceHandle.getProxy(), params);
    }
 
 }

--- a/microservices/src/main/java/io/silverware/microservices/silver/cluster/LocalServiceHandle.java
+++ b/microservices/src/main/java/io/silverware/microservices/silver/cluster/LocalServiceHandle.java
@@ -133,14 +133,5 @@ public class LocalServiceHandle implements ServiceHandle {
       return response;
    }
 
-   @Override
-   public Object invoke(final Context context, final String method, final Object[] params) throws Exception {
-      final Class[] paramTypes = new Class[params.length];
-      for (int i = 0; i < params.length; i++) {
-         paramTypes[i] = params[i].getClass();
-      }
-
-      return invoke(context, method, paramTypes, params);
-   }
 
 }

--- a/microservices/src/main/java/io/silverware/microservices/silver/cluster/LocalServiceHandle.java
+++ b/microservices/src/main/java/io/silverware/microservices/silver/cluster/LocalServiceHandle.java
@@ -66,16 +66,17 @@ public class LocalServiceHandle implements ServiceHandle {
    }
 
    @Override
+   public Object getProxy() {
+      return service;
+   }
+
+   @Override
    public String getHost() {
       return host;
    }
 
    public MicroserviceMetaData getQuery() {
       return query;
-   }
-
-   public Object getService() {
-      return service;
    }
 
    @Override
@@ -132,6 +133,5 @@ public class LocalServiceHandle implements ServiceHandle {
 
       return response;
    }
-
 
 }

--- a/microservices/src/main/java/io/silverware/microservices/silver/cluster/RemoteServiceHandlesStore.java
+++ b/microservices/src/main/java/io/silverware/microservices/silver/cluster/RemoteServiceHandlesStore.java
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
  */
 public class RemoteServiceHandlesStore {
 
-   private Map<MicroserviceMetaData, Set<ServiceHandle>> outboundHandles;
+   private final Map<MicroserviceMetaData, Set<ServiceHandle>> outboundHandles;
 
    public RemoteServiceHandlesStore() {
       this.outboundHandles = new ConcurrentHashMap<>();
@@ -86,6 +86,6 @@ public class RemoteServiceHandlesStore {
     * @return collection of services which can be called for given metadata
     */
    public Set<Object> getServices(MicroserviceMetaData metaData) {
-      return outboundHandles.getOrDefault(metaData, Collections.emptySet()).stream().collect(Collectors.toSet());
+      return outboundHandles.getOrDefault(metaData, Collections.emptySet()).stream().map(ServiceHandle::getProxy).collect(Collectors.toSet());
    }
 }

--- a/microservices/src/main/java/io/silverware/microservices/silver/cluster/ServiceHandle.java
+++ b/microservices/src/main/java/io/silverware/microservices/silver/cluster/ServiceHandle.java
@@ -24,15 +24,25 @@ import io.silverware.microservices.Context;
 import java.io.Serializable;
 
 /**
- *  This class represents a handle for a service object
+ * This class represents a handle for a service object
+ *
  * @author Slavomír Krupa (slavomir.krupa@gmail.com)
  */
 public interface ServiceHandle extends Serializable {
 
    String getHost();
 
+   /**
+    * This method invokes requested method for a given handle
+    * and
+    *
+    * @param context    of the
+    * @param method     name of the method to be called
+    * @param params     parameters of method called
+    * @param paramTypes classes of parameters
+    * @return result of call
+    * @throws Exception if exception has occurred during invocation
+    */
    Object invoke(Context context, String method, Class[] paramTypes, Object[] params) throws Exception;
 
-   @Deprecated
-   Object invoke(Context context, String method, Object[] params) throws Exception;
 }

--- a/microservices/src/main/java/io/silverware/microservices/silver/cluster/ServiceHandle.java
+++ b/microservices/src/main/java/io/silverware/microservices/silver/cluster/ServiceHandle.java
@@ -30,6 +30,11 @@ import java.io.Serializable;
  */
 public interface ServiceHandle extends Serializable {
 
+   /**
+    * @return proxy for a given service handle
+    */
+   Object getProxy();
+
    String getHost();
 
    /**


### PR DESCRIPTION
- removed the deprecated method of invocation where the parameter types were resolved from the params ( problems with primitive types and null params)
- changed levels of log messages in a cluster cdi module for clearer info about state
- added timeout for the first time lookup of remote microsrvices which can be set as variable in properties file : `silverware.cluster.lookup.timeout`
- some fixes in tests for windows platform (paths and timeouts)
