### PR TITLE
Fix class discovery in MicroserviceProxyFactory

### DIFF
--- a/camel-microservice-provider/src/main/java/io/silverware/microservices/providers/camel/CamelMicroserviceProvider.java
+++ b/camel-microservice-provider/src/main/java/io/silverware/microservices/providers/camel/CamelMicroserviceProvider.java
@@ -65,13 +65,12 @@ public class CamelMicroserviceProvider implements MicroserviceProvider, CamelSil
    private final DeployStats stats = new DeployStats();
 
    private void createCamelContext() throws SilverWareException {
-      @SuppressWarnings("unchecked")
-      Set<Class<CamelContextFactory>> camelContextFactories = DeploymentScanner.getContextInstance(context).lookupSubtypes(CamelContextFactory.class);
+      Set<Class<? extends CamelContextFactory>> camelContextFactories = DeploymentScanner.getContextInstance(context).lookupSubtypes(CamelContextFactory.class);
 
       if (camelContextFactories.size() >= 2) {
          throw new SilverWareException("More than one CamelContextFactories found.");
       } else if (camelContextFactories.size() == 1) {
-         Class<CamelContextFactory> clazz = camelContextFactories.iterator().next();
+         Class<? extends CamelContextFactory> clazz = camelContextFactories.iterator().next();
          try {
             CamelContextFactory camelContextFactory = clazz.newInstance();
             camelContext = camelContextFactory.createCamelContext(context);
@@ -86,14 +85,13 @@ public class CamelMicroserviceProvider implements MicroserviceProvider, CamelSil
    }
 
    private void loadRoutesFromClasses() {
-      @SuppressWarnings("unchecked")
-      final Set<Class<RouteBuilder>> routeBuilders = (Set<Class<RouteBuilder>>) DeploymentScanner.getContextInstance(context).lookupSubtypes(RouteBuilder.class);
+      final Set<Class<? extends RouteBuilder>> routeBuilders = DeploymentScanner.getContextInstance(context).lookupSubtypes(RouteBuilder.class);
       if (log.isDebugEnabled()) {
          log.debug("Initializing Camel route resources...");
       }
       stats.setFound(routeBuilders.size());
 
-      for (Class<RouteBuilder> clazz : routeBuilders) {
+      for (Class<? extends RouteBuilder> clazz : routeBuilders) {
          if (log.isDebugEnabled()) {
             log.debug("Creating Camel route builder: " + clazz.getName());
          }

--- a/cdi-microservice-provider/src/main/java/io/silverware/microservices/providers/cdi/internal/MicroserviceProxyFactory.java
+++ b/cdi-microservice-provider/src/main/java/io/silverware/microservices/providers/cdi/internal/MicroserviceProxyFactory.java
@@ -19,16 +19,14 @@
  */
 package io.silverware.microservices.providers.cdi.internal;
 
-import org.reflections.Reflections;
-import org.reflections.scanners.ResourcesScanner;
-import org.reflections.util.ConfigurationBuilder;
-
 import java.lang.reflect.Constructor;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Priority;
 
+import io.silverware.microservices.util.DeploymentScanner;
 import javassist.util.proxy.MethodHandler;
 import javassist.util.proxy.ProxyFactory;
 
@@ -45,14 +43,12 @@ public class MicroserviceProxyFactory {
    private static final List<Class<? extends MicroserviceMethodHandler>> HANDLER_CLASSES;
 
    static {
-      ConfigurationBuilder builder = ConfigurationBuilder.build("").addScanners(new ResourcesScanner());
-      Reflections reflections = new Reflections(builder);
+      Set<Class<? extends MicroserviceMethodHandler>> handlerClasses = DeploymentScanner.getDefaultInstance().lookupSubtypes(MicroserviceMethodHandler.class);
 
-      HANDLER_CLASSES = reflections.getSubTypesOf(MicroserviceMethodHandler.class)
-                                   .stream()
-                                   .filter(handler -> handler != DefaultMethodHandler.class)
-                                   .sorted(new MethodHandlerPrioritizer())
-                                   .collect(Collectors.toList());
+      HANDLER_CLASSES = handlerClasses.stream()
+                                      .filter(handler -> handler != DefaultMethodHandler.class)
+                                      .sorted(new MethodHandlerPrioritizer())
+                                      .collect(Collectors.toList());
    }
 
    private MicroserviceProxyFactory() {

--- a/microservices/src/main/java/io/silverware/microservices/util/DeploymentScanner.java
+++ b/microservices/src/main/java/io/silverware/microservices/util/DeploymentScanner.java
@@ -163,7 +163,7 @@ public class DeploymentScanner {
     * @return All available classes of the given subtype.
     */
    @SuppressWarnings("unchecked")
-   public Set lookupSubtypes(final Class clazz) {
+   public <T> Set<Class<? extends T>> lookupSubtypes(final Class<T> clazz) {
       return reflections.getSubTypesOf(clazz);
       /*final Set s1 = reflections.getSubTypesOf(clazz);
       final Set s2 = Sets.newHashSet(ReflectionUtils.forNames(

--- a/vertx-microservice-provider/src/main/java/io/silverware/microservices/providers/vertx/VertxMicroserviceProvider.java
+++ b/vertx-microservice-provider/src/main/java/io/silverware/microservices/providers/vertx/VertxMicroserviceProvider.java
@@ -131,12 +131,9 @@ public class VertxMicroserviceProvider implements MicroserviceProvider, VertxSil
    }
 
    private void loadJavaVerticles() {
+      Set<Class<? extends Verticle>> verticleClasses = DeploymentScanner.getContextInstance(context).lookupSubtypes(Verticle.class);
 
-      @SuppressWarnings("unchecked")
-      Set<Class<Verticle>> verticleClasses = (Set<Class<Verticle>>) DeploymentScanner.getContextInstance(context)
-              .lookupSubtypes(Verticle.class);
-
-      for (Class<Verticle> verticleClass : verticleClasses) {
+      for (Class<? extends Verticle> verticleClass : verticleClasses) {
 
          Deployment deployment = verticleClass.getAnnotation(Deployment.class);
 
@@ -150,12 +147,9 @@ public class VertxMicroserviceProvider implements MicroserviceProvider, VertxSil
    }
 
    private void loadGroovyVerticles() {
+      Set<Class<? extends GroovyVerticle>> groovyVerticleClasses = DeploymentScanner.getContextInstance(context).lookupSubtypes(GroovyVerticle.class);
 
-      @SuppressWarnings("unchecked")
-      Set<Class<GroovyVerticle>> groovyVerticleClasses = (Set<Class<GroovyVerticle>>) DeploymentScanner
-              .getContextInstance(context).lookupSubtypes(GroovyVerticle.class);
-
-      for (Class<GroovyVerticle> groovyVerticleClass : groovyVerticleClasses) {
+      for (Class<? extends GroovyVerticle> groovyVerticleClass : groovyVerticleClasses) {
 
          Deployment deployment = groovyVerticleClass.getAnnotation(Deployment.class);
 


### PR DESCRIPTION
`MicroserviceMethodHandler` implementations from other providers were not discovered before. The actual fix is in the usage of `DeploymentScanner`. One method in this class was slightly changed which required further changes in other classes.
