### PR TITLE
[#47] [#34] Implement version lookup and fix cluster lookup

### DIFF
--- a/cdi-microservice-provider/src/main/java/io/silverware/microservices/annotations/MicroserviceVersion.java
+++ b/cdi-microservice-provider/src/main/java/io/silverware/microservices/annotations/MicroserviceVersion.java
@@ -1,0 +1,57 @@
+/*
+ * -----------------------------------------------------------------------\
+ * SilverWare
+ *  
+ * Copyright (C) 2010 - 2016 the original author or authors.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------/
+ */
+package io.silverware.microservices.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation can be used in two different scenarios:
+ * <ul>
+ * <li><strong>Microservice:</strong> can specify version of Microservice Implementation and API. </li>
+ * <li><strong>Injection point:</strong> can specify supported version of a Microservice API. </li>
+ * </ul>
+ * These versions are used in the lookup of the Microservices in the cluster.
+ * See @{@link io.silverware.microservices.providers.cdi.util.VersionResolver}
+ * See @{@link io.silverware.microservices.util.VersionComparator}
+ *
+ * @author Slavomír Krupa (slavomir.krupa@gmail.com)
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@Target({ ElementType.TYPE })
+public @interface MicroserviceVersion {
+
+   /**
+    * Gets the API version of the Microservice.
+    */
+   String api() default "";
+
+   /**
+    * Gets the implementation version of the Microservice.
+    * If not defined then {@link io.silverware.microservices.providers.cdi.util.VersionResolver} continues in search for microservice version.
+    */
+   String implementation() default "";
+}

--- a/cdi-microservice-provider/src/main/java/io/silverware/microservices/providers/cdi/internal/DefaultMethodHandler.java
+++ b/cdi-microservice-provider/src/main/java/io/silverware/microservices/providers/cdi/internal/DefaultMethodHandler.java
@@ -19,6 +19,12 @@
  */
 package io.silverware.microservices.providers.cdi.internal;
 
+import io.silverware.microservices.MicroserviceMetaData;
+import io.silverware.microservices.annotations.MicroserviceReference;
+import io.silverware.microservices.providers.cdi.util.VersionResolver;
+import io.silverware.microservices.silver.services.LookupStrategy;
+import io.silverware.microservices.silver.services.LookupStrategyFactory;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -27,11 +33,6 @@ import java.lang.reflect.Method;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Priority;
-
-import io.silverware.microservices.MicroserviceMetaData;
-import io.silverware.microservices.annotations.MicroserviceReference;
-import io.silverware.microservices.silver.services.LookupStrategy;
-import io.silverware.microservices.silver.services.LookupStrategyFactory;
 
 /**
  * Default microservice method handler which is invoked as the last one and makes an actual call on the service instance.
@@ -49,7 +50,7 @@ public class DefaultMethodHandler extends MicroserviceMethodHandler {
       this.proxyBean = proxyBean;
 
       final Set<Annotation> qualifiers = proxyBean.getQualifiers().stream().filter(qualifier -> !qualifier.annotationType().getName().equals(MicroserviceReference.class.getName())).collect(Collectors.toSet());
-      final MicroserviceMetaData metaData = new MicroserviceMetaData(proxyBean.getMicroserviceName(), proxyBean.getServiceInterface(), qualifiers, proxyBean.getAnnotations());
+      final MicroserviceMetaData metaData = VersionResolver.createMicroserviceMetadata(proxyBean.getMicroserviceName(), proxyBean.getServiceInterface(), qualifiers, proxyBean.getAnnotations());
 
       this.lookupStrategy = LookupStrategyFactory.getStrategy(proxyBean.getContext(), metaData, proxyBean.getAnnotations());
    }

--- a/cdi-microservice-provider/src/main/java/io/silverware/microservices/providers/cdi/internal/MicroservicesCDIExtension.java
+++ b/cdi-microservice-provider/src/main/java/io/silverware/microservices/providers/cdi/internal/MicroservicesCDIExtension.java
@@ -24,6 +24,7 @@ import io.silverware.microservices.MicroserviceMetaData;
 import io.silverware.microservices.annotations.Microservice;
 import io.silverware.microservices.annotations.MicroserviceReference;
 import io.silverware.microservices.providers.cdi.MicroserviceContext;
+import io.silverware.microservices.providers.cdi.util.VersionResolver;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -86,10 +87,8 @@ public class MicroservicesCDIExtension implements Extension {
    /**
     * {@link javax.enterprise.inject.spi.BeforeBeanDiscovery} CDI event observer.
     *
-    * @param beforeEvent
-    *       CDI Event instance.
-    * @param beanManager
-    *       CDI Bean Manager instance.
+    * @param beforeEvent CDI Event instance.
+    * @param beanManager CDI Bean Manager instance.
     */
    public void beforeBeanDiscovery(@Observes final BeforeBeanDiscovery beforeEvent, final BeanManager beanManager) {
       if (log.isDebugEnabled()) {
@@ -100,10 +99,8 @@ public class MicroservicesCDIExtension implements Extension {
    /**
     * {@link javax.enterprise.inject.spi.ProcessBean} CDI event observer.
     *
-    * @param processBean
-    *       CDI Event instance.
-    * @param beanManager
-    *       CDI Bean Manager instance.
+    * @param processBean CDI Event instance.
+    * @param beanManager CDI Bean Manager instance.
     */
    public void processBean(@Observes final ProcessBean processBean, final BeanManager beanManager) {
       final Bean<?> bean = processBean.getBean();
@@ -156,8 +153,7 @@ public class MicroservicesCDIExtension implements Extension {
    /**
     * {@link javax.enterprise.inject.spi.ProcessBean} CDI event observer.
     *
-    * @param afterEvent
-    *       CDI Event instance.
+    * @param afterEvent CDI Event instance.
     */
    public void afterBeanDiscovery(@Observes final AfterBeanDiscovery afterEvent) {
       afterEvent.addContext(new MicroserviceContext());
@@ -216,6 +212,7 @@ public class MicroservicesCDIExtension implements Extension {
 
    /**
     * Gets the number of discovered injection points.
+    *
     * @return The number of discovered injection points.
     */
    public long getInjectionPointsCount() {
@@ -224,13 +221,14 @@ public class MicroservicesCDIExtension implements Extension {
 
    /**
     * Gets a new {@link MicroserviceMetaData} descriptor based on the provided CDI bean.
+    *
     * @param microserviceName The Microservice name.
-    * @param bean The CDI Bean.
+    * @param bean             The CDI Bean.
     * @return Microservice meta-data.
     */
    private MicroserviceMetaData getMicroserviceMetaData(final String microserviceName, final Bean<?> bean) {
-      return new MicroserviceMetaData(microserviceName, bean.getBeanClass(), bean.getQualifiers(), new HashSet<>(
-            Arrays.asList(bean.getBeanClass().getAnnotations())));
+      return VersionResolver.createMicroserviceMetadata(microserviceName, bean.getBeanClass(), bean.getQualifiers(), new HashSet<>(
+              Arrays.asList(bean.getBeanClass().getAnnotations())));
    }
 
    /**

--- a/cdi-microservice-provider/src/main/java/io/silverware/microservices/providers/cdi/util/VersionResolver.java
+++ b/cdi-microservice-provider/src/main/java/io/silverware/microservices/providers/cdi/util/VersionResolver.java
@@ -1,0 +1,184 @@
+/*
+ * -----------------------------------------------------------------------\
+ * SilverWare
+ *  
+ * Copyright (C) 2010 - 2016 the original author or authors.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------/
+ */
+package io.silverware.microservices.providers.cdi.util;
+
+import io.silverware.microservices.MicroserviceMetaData;
+import io.silverware.microservices.annotations.MicroserviceVersion;
+import io.silverware.microservices.util.Utils;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * This class is used for resolving of api and implementation versions.
+ * The resolution process takes the first version which is provided for the microservice from following list
+ * <ol>
+ * <li>MicroserviceVersion annotation on bean</li>
+ * <li>MicroserviceVersion annotation on class</li>
+ * <li>MicroserviceVersion annotation on interfaces</li>
+ * <li>MicroserviceVersion annotation on parent classes</li>
+ * <li>Manifest version</li>
+ * </ol>
+ * If no version was obtained using this process null will be returned.
+ * See @{@link MicroserviceVersion}
+ * See @{@link io.silverware.microservices.util.VersionComparator}
+ *
+ * @author Slavomír Krupa (slavomir.krupa@gmail.com)
+ */
+public final class VersionResolver {
+   public static final java.util.function.Predicate<Annotation> IS_ANNOTATION_MICROSERVICE_VERSION = annotation -> MicroserviceVersion.class.isAssignableFrom(annotation.getClass());
+   /**
+    * Logger.
+    */
+   private static final Logger log = LogManager.getLogger(VersionResolver.class);
+
+   public static final String SPECIFICATION_VERSION = "Specification-Version";
+   public static final String IMPLEMENTATION_VERSION = "Implementation-Version";
+
+   private VersionResolver() {
+   }
+
+   /**
+    * Create a instance of a Microservice meta data which represents discovered Microservice.
+    *
+    * @param name
+    *       The name of the discovered Microservice.
+    * @param type
+    *       The type of the discovered Microservice.
+    * @param qualifiers
+    *       The qualifiers of the discovered Microservice.
+    * @param annotations
+    *       The annotations of the discovered Microservice.
+    */
+   public static MicroserviceMetaData createMicroserviceMetadata(final String name, final Class type, final Set<Annotation> qualifiers, final Set<Annotation> annotations) {
+      String apiVersion = resolveApiVersion(type, annotations);
+      String implVersion = resolveImplementationVersion(type, annotations);
+      return new MicroserviceMetaData(name, type, qualifiers, annotations, apiVersion, implVersion);
+
+   }
+
+   /**
+    * Use the process mentioned in @{@link VersionResolver} to obtain api version.
+    *
+    * @param clazz
+    *       The class I want to obtain version of.
+    * @param annotations
+    *       list of a annotations from service
+    * @return The class specification version from manifest, null if there is no version information present or the manifest file does not exists.
+    */
+   public static String resolveApiVersion(final Class clazz, final Set<Annotation> annotations) {
+      return resolveVersion(clazz, annotations, MicroserviceVersion::api, SPECIFICATION_VERSION);
+   }
+
+   /**
+    * Use the process mentioned in @{@link VersionResolver} to obtain implementation version.
+    *
+    * @param clazz
+    *       The class I want to obtain version of.
+    * @param annotations
+    *       list of a annotations from service
+    * @return The class specification version from manifest, null if there is no version information present or the manifest file does not exists.
+    */
+   public static String resolveImplementationVersion(final Class clazz, final Set<Annotation> annotations) {
+      return resolveVersion(clazz, annotations, MicroserviceVersion::implementation, IMPLEMENTATION_VERSION);
+   }
+
+   private static String resolveVersion(final Class clazz, final Set<Annotation> annotations, Function<MicroserviceVersion, String> lambda, final String versionType) {
+      String version = null;
+      if (annotations != null) {
+         version = resolveVersionFromAnnotations(annotations.stream(), lambda);
+      }
+      if (version == null && clazz.getAnnotations() != null) {
+         version = resolveVersionFromAnnotations(Arrays.stream(clazz.getAnnotations()), lambda);
+      }
+      if (version == null) {
+         version = resolveVersionFromInterfacesClasses(clazz, lambda);
+      }
+      if (version == null) {
+         version = resolveVersionFromSuperClasses(clazz, lambda);
+      }
+      if (version == null) {
+         version = getClassVersionFromManifest(clazz, versionType);
+      }
+      return version;
+   }
+
+   private static String resolveVersionFromSuperClasses(final Class clazz, final Function<MicroserviceVersion, String> lambda) {
+      Class classToProcess = clazz.getSuperclass();
+      String version = null;
+      while (classToProcess != null && !classToProcess.equals(Object.class) && version == null) {
+         version = resolveVersionFromAnnotations(Arrays.stream(classToProcess.getAnnotations()), lambda);
+         classToProcess = classToProcess.getSuperclass();
+      }
+      return version;
+   }
+
+   private static String resolveVersionFromInterfacesClasses(final Class clazz, Function<MicroserviceVersion, String> lambda) {
+      Class[] interfaces = clazz.getInterfaces();
+      List<String> versions = Arrays.stream(interfaces)
+                                    .map(i -> resolveVersionFromAnnotations(Arrays.stream(i.getAnnotations()), lambda))
+                                    .collect(Collectors.toList());
+      if (versions.size() > 1) {
+         throw new IllegalArgumentException("Microservice version annotation present at more interfaces.");
+      }
+      return versions.isEmpty() ? null : versions.get(0);
+
+   }
+
+   private static String resolveVersionFromAnnotations(Stream<Annotation> annotations, Function<MicroserviceVersion, String> lambda) {
+      if (annotations != null) {
+         Optional<Annotation> annotation = annotations.filter(IS_ANNOTATION_MICROSERVICE_VERSION).findFirst();
+         if (annotation.isPresent()) {
+            return lambda.apply((MicroserviceVersion) annotation.get());
+         }
+      }
+      return null;
+   }
+
+   /**
+    * Gets the class implementation version from manifest.
+    *
+    * @param clazz
+    *       The class I want to obtain version of.
+    * @return The class specification version from manifest, null if there is no version information present or the manifest file does not exists.
+    */
+   private static String getClassVersionFromManifest(final Class clazz, final String versionType) {
+      try {
+         return Utils.getManifestEntry(clazz, versionType);
+      } catch (IOException ioe) {
+         if (log.isDebugEnabled()) {
+            log.debug("Cannot obtain version for class {}.", clazz.getName());
+         }
+      }
+
+      return null;
+   }
+
+}

--- a/cdi-microservice-provider/src/test/java/io/silverware/microservices/providers/cdi/CdiMicroserviceProviderAlternativesTest.java
+++ b/cdi-microservice-provider/src/test/java/io/silverware/microservices/providers/cdi/CdiMicroserviceProviderAlternativesTest.java
@@ -22,17 +22,17 @@ package io.silverware.microservices.providers.cdi;
 import io.silverware.microservices.annotations.Microservice;
 import io.silverware.microservices.annotations.MicroserviceReference;
 import io.silverware.microservices.util.BootUtil;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import javax.enterprise.event.Observes;
-import javax.enterprise.inject.Alternative;
-import javax.enterprise.inject.spi.BeanManager;
-import javax.inject.Inject;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.Alternative;
+import javax.inject.Inject;
 
 /**
  * @author <a href="mailto:marvenec@gmail.com">Martin Večeřa</a>
@@ -52,7 +52,7 @@ public class CdiMicroserviceProviderAlternativesTest {
 
       CdiMicroserviceProviderTestUtil.waitForBeanManager(bootUtil);
 
-      Assert.assertTrue(semaphore.tryAcquire(100, TimeUnit.MINUTES), "Timed-out while waiting for platform startup.");
+      Assert.assertTrue(semaphore.tryAcquire(1, TimeUnit.MINUTES), "Timed-out while waiting for platform startup.");
       Assert.assertEquals(result, "alternatealternate");
 
       platform.interrupt();

--- a/cdi-microservice-provider/src/test/java/io/silverware/microservices/providers/cdi/CdiMicroserviceProviderBasicTest.java
+++ b/cdi-microservice-provider/src/test/java/io/silverware/microservices/providers/cdi/CdiMicroserviceProviderBasicTest.java
@@ -22,17 +22,17 @@ package io.silverware.microservices.providers.cdi;
 import io.silverware.microservices.annotations.Microservice;
 import io.silverware.microservices.annotations.MicroserviceReference;
 import io.silverware.microservices.util.BootUtil;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import javax.annotation.PostConstruct;
-import javax.enterprise.event.Observes;
-import javax.enterprise.inject.spi.BeanManager;
-import javax.inject.Inject;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.PostConstruct;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
 
 /**
  * @author <a href="mailto:marvenec@gmail.com">Martin Večeřa</a>
@@ -58,7 +58,7 @@ public class CdiMicroserviceProviderBasicTest {
 
       //testMicroserviceB = (TestMicroserviceB) CdiMicroserviceProvider.getMicroserviceProxy(bootUtil.getContext(), TestMicroserviceB.class);
 
-      Assert.assertTrue(semaphore.tryAcquire(10, TimeUnit.MINUTES), "Timed-out while waiting for platform startup.");
+      Assert.assertTrue(semaphore.tryAcquire(1, TimeUnit.MINUTES), "Timed-out while waiting for platform startup.");
       Assert.assertTrue(postConstructCalled);
       Assert.assertEquals(result, "micrononame");
 

--- a/cdi-microservice-provider/src/test/java/io/silverware/microservices/providers/cdi/CdiMicroserviceProviderVersionsTest.java
+++ b/cdi-microservice-provider/src/test/java/io/silverware/microservices/providers/cdi/CdiMicroserviceProviderVersionsTest.java
@@ -2,7 +2,7 @@
  * -----------------------------------------------------------------------\
  * SilverWare
  *  
- * Copyright (C) 2010 - 2013 the original author or authors.
+ * Copyright (C) 2010 - 2016 the original author or authors.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,36 +21,29 @@ package io.silverware.microservices.providers.cdi;
 
 import io.silverware.microservices.annotations.Microservice;
 import io.silverware.microservices.annotations.MicroserviceReference;
+import io.silverware.microservices.annotations.MicroserviceVersion;
 import io.silverware.microservices.util.BootUtil;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import javax.enterprise.event.Observes;
-import javax.enterprise.inject.Specializes;
 import javax.inject.Inject;
-import javax.inject.Qualifier;
 
 /**
- * @author <a href="mailto:marvenec@gmail.com">Martin Večeřa</a>
+ * Basic test for versioning.
+ *
+ * @author Slavomir Krupa (slavomir.krupa@gmail.com)
  */
-public class CdiMicroserviceProviderSpecializationTest {
-
-   private static final Logger log = LogManager.getLogger(CdiMicroserviceProviderSpecializationTest.class);
+public class CdiMicroserviceProviderVersionsTest {
 
    private static final Semaphore semaphore = new Semaphore(0);
    private static String result = "";
 
    @Test
-   public void testQualifiers() throws Exception {
+   public void testBasicVersionResolution() throws Exception {
       final BootUtil bootUtil = new BootUtil();
       final Thread platform = bootUtil.getMicroservicePlatform(this.getClass().getPackage().getName());
       platform.start();
@@ -58,60 +51,67 @@ public class CdiMicroserviceProviderSpecializationTest {
       CdiMicroserviceProviderTestUtil.waitForBeanManager(bootUtil);
 
       Assert.assertTrue(semaphore.tryAcquire(1, TimeUnit.MINUTES), "Timed-out while waiting for platform startup.");
-      Assert.assertEquals(result, "specialspecial");
+      Assert.assertEquals(result, "hello2bye1");
 
       platform.interrupt();
       platform.join();
    }
 
-   @Microservice
-   public static class TestSpecializationMicroservice {
+   @Microservice("basic")
+   public static class TestVersionMicroservice {
 
       @Inject
-      @Sharp
       @MicroserviceReference
-      private SpecializationMicro micro1;
+      private HelloVersion2 micro1;
 
       @Inject
-      @Sharp
       @MicroserviceReference
-      private SpecializationMicro micro2;
+      private ByeVersion1 micro2;
 
       public void eventObserver(@Observes MicroservicesStartedEvent event) {
          result += micro1.hello();
-         result += micro2.hello();
-
+         result += micro2.bye();
          semaphore.release();
       }
    }
 
-   public interface SpecializationMicro {
+   @MicroserviceVersion(api = "2.2.2")
+   public interface HelloVersion2 {
       String hello();
    }
 
-   @Sharp
+   @MicroserviceVersion(api = "1.1.1")
+   public interface ByeVersion1 {
+      String bye();
+   }
+
    @Microservice
-   public static class SpecializationMicroBean implements SpecializationMicro {
+   @MicroserviceVersion(implementation = "1.1.1")
+   public static class Version1MicroBean implements HelloVersion2, ByeVersion1 {
 
       @Override
       public String hello() {
-         return "normal";
+         return "hello1";
+      }
+
+      @Override
+      public String bye() {
+         return "bye1";
       }
    }
 
-   @Specializes
-   public static class MockSpecializationMicroBean extends SpecializationMicroBean {
+   @Microservice
+   @MicroserviceVersion(implementation = "2.2.2")
+   public static class Version2MicroBean implements HelloVersion2, ByeVersion1 {
 
       @Override
       public String hello() {
-         return "special";
+         return "hello2";
+      }
+
+      @Override
+      public String bye() {
+         return "bye2";
       }
    }
-
-   @Qualifier
-   @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
-   @Retention(RetentionPolicy.RUNTIME)
-   public @interface Sharp {
-   }
-
 }

--- a/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/HttpServiceProxy.java
+++ b/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/HttpServiceProxy.java
@@ -22,6 +22,7 @@ package io.silverware.microservices.providers.cluster.internal;
 import io.silverware.microservices.Context;
 import io.silverware.microservices.silver.cluster.LocalServiceHandle;
 import io.silverware.microservices.silver.cluster.ServiceHandle;
+
 import javassist.util.proxy.MethodHandler;
 import javassist.util.proxy.ProxyFactory;
 
@@ -51,19 +52,19 @@ public class HttpServiceProxy implements MethodHandler {
    public static <T> T getProxy(final Context context, final LocalServiceHandle serviceHandle) {
       try {
          ProxyFactory factory = new ProxyFactory();
-         if (serviceHandle.getQuery().getType().isInterface()) {
-            factory.setInterfaces(new Class[] { serviceHandle.getQuery().getType() });
+         if (serviceHandle.getMetaData().getType().isInterface()) {
+            factory.setInterfaces(new Class[]{serviceHandle.getMetaData().getType()});
          } else {
-            factory.setSuperclass(serviceHandle.getQuery().getType());
+            factory.setSuperclass(serviceHandle.getMetaData().getType());
          }
          return (T) factory.create(new Class[0], new Object[0], new HttpServiceProxy(context, serviceHandle));
       } catch (Exception e) {
-         throw new IllegalStateException("Cannot create Http proxy for class " + serviceHandle.getQuery().getType().getName() + ": ", e);
+         throw new IllegalStateException("Cannot create Http proxy for class " + serviceHandle.getMetaData().getType().getName() + ": ", e);
       }
    }
 
    @Override
    public Object invoke(final Object o, final Method method, final Method method1, final Object[] objects) throws Throwable {
-      return serviceHandle.invoke(context, method.getName(),method.getParameterTypes(), objects);
+      return serviceHandle.invoke(context, method.getName(), method.getParameterTypes(), objects);
    }
 }

--- a/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/JgroupsMessageReceiver.java
+++ b/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/JgroupsMessageReceiver.java
@@ -2,7 +2,7 @@
  * -----------------------------------------------------------------------\
  * SilverWare
  *  
- * Copyright (C) 2010 - 2013 the original author or authors.
+ * Copyright (C) 2010 - 2016 the original author or authors.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,14 @@
  */
 package io.silverware.microservices.providers.cluster.internal;
 
+import static io.silverware.microservices.providers.cluster.internal.exception.SilverWareClusteringException.SilverWareClusteringError.PROCESSING_ERROR;
+import static io.silverware.microservices.providers.cluster.internal.exception.SilverWareClusteringException.SilverWareClusteringError.RECIPIENT_SAME_AS_SENDER;
+import static io.silverware.microservices.providers.cluster.internal.exception.SilverWareClusteringException.SilverWareClusteringError.UNEXPECTED_CONTENT;
+
 import io.silverware.microservices.providers.cluster.internal.exception.SilverWareClusteringException;
 import io.silverware.microservices.providers.cluster.internal.message.responder.Responder;
 import io.silverware.microservices.silver.cluster.RemoteServiceHandlesStore;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jgroups.Address;
@@ -34,10 +39,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import static io.silverware.microservices.providers.cluster.internal.exception.SilverWareClusteringException.SilverWareClusteringError.PROCESSING_ERROR;
-import static io.silverware.microservices.providers.cluster.internal.exception.SilverWareClusteringException.SilverWareClusteringError.RECIPIENT_SAME_AS_SENDER;
-import static io.silverware.microservices.providers.cluster.internal.exception.SilverWareClusteringException.SilverWareClusteringError.UNEXPECTED_CONTENT;
 
 /**
  * Class responsible for retrieving messages
@@ -86,7 +87,6 @@ public class JgroupsMessageReceiver extends ReceiverAdapter implements RequestHa
       store.keepHandlesFor(addresses);
       log.info("Cluster view change: " + view);
    }
-
 
    @Override
    public Object handle(Message msg) throws Exception {

--- a/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/JgroupsMessageSender.java
+++ b/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/JgroupsMessageSender.java
@@ -2,7 +2,7 @@
  * -----------------------------------------------------------------------\
  * SilverWare
  *  
- * Copyright (C) 2010 - 2013 the original author or authors.
+ * Copyright (C) 2010 - 2016 the original author or authors.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,10 +47,8 @@ public class JgroupsMessageSender {
     */
    private static final Logger log = LogManager.getLogger(JgroupsMessageSender.class);
 
-
    private static final RequestOptions SYNC_OPTIONS = RequestOptions.SYNC();
    private static final RequestOptions ASYNC_OPTIONS = RequestOptions.ASYNC();
-
 
    private final MessageDispatcher dispatcher;
    private Set<Address> filteredAdresses;
@@ -62,13 +60,11 @@ public class JgroupsMessageSender {
       this.dispatcher = dispatcher;
    }
 
-   private Set<Address> getFilteredAdresses() {
+   private Set<Address> getFilteredAddresses() {
       if (this.filteredAdresses == null) {
          this.filteredAdresses = new HashSet<>();
          // add my address
          filteredAdresses.add(this.dispatcher.getChannel().getAddress());
-         // add cluster address
-         filteredAdresses.add(this.dispatcher.getChannel().getView().getCreator());
       }
       return this.filteredAdresses;
    }
@@ -76,22 +72,25 @@ public class JgroupsMessageSender {
    /**
     * Send multicast message to all nodes in cluster
     *
-    * @param content content of message
+    * @param content
+    *       content of message
     */
    public <T> RspList<T> sendToClusterSync(Serializable content) throws Exception {
-      return this.dispatcher.castMessage(getMembersAdresses(), new Message(null, content), SYNC_OPTIONS);
+      return this.dispatcher.castMessage(getMembersAddresses(), new Message(null, content), SYNC_OPTIONS);
    }
 
    /**
     * Send async multicast message to all nodes in cluster
     *
-    * @param content  content of message
-    * @param listener listener which will be called when result will be available
+    * @param content
+    *       content of message
+    * @param listener
+    *       listener which will be called when result will be available
     */
    public <T> void sendToClusterAsync(Serializable content, Set<Address> addressesToSkip, FutureListener<RspList<T>> listener) throws Exception {
-      List<Address> othertMembersAdresses = getOthertMembersAdresses().stream().filter(address -> !addressesToSkip.contains(address)).collect(Collectors.toList());
-      if (!othertMembersAdresses.isEmpty()) {
-         this.dispatcher.castMessageWithFuture(othertMembersAdresses, new Message(null, content), SYNC_OPTIONS, listener);
+      List<Address> otherMembersAddresses = getOtherMembersAddresses().stream().filter(address -> !addressesToSkip.contains(address)).collect(Collectors.toList());
+      if (!otherMembersAddresses.isEmpty()) {
+         this.dispatcher.castMessageWithFuture(otherMembersAddresses, new Message(null, content), SYNC_OPTIONS, listener);
       } else {
          if (log.isDebugEnabled()) {
             log.debug("No message sent.");
@@ -102,26 +101,29 @@ public class JgroupsMessageSender {
    /**
     * Send async multicast message to all nodes in cluster
     *
-    * @param content  content of message
-    * @param listener listener which will be called when result will be available
+    * @param content
+    *       content of message
+    * @param listener
+    *       listener which will be called when result will be available
     */
    public <T> void sendToClusterAsync(Serializable content, FutureListener<RspList<T>> listener) throws Exception {
       sendToClusterAsync(content, Collections.emptySet(), listener);
    }
 
-   private List<Address> getMembersAdresses() {
+   private List<Address> getMembersAddresses() {
       return this.dispatcher.getChannel().getView().getMembers();
    }
 
-   private List<Address> getOthertMembersAdresses() {
-      Set<Address> filteredAdresses = getFilteredAdresses();
-      return this.getMembersAdresses().stream().filter(address -> !filteredAdresses.contains(address)).collect(Collectors.toList());
+   private List<Address> getOtherMembersAddresses() {
+      Set<Address> filteredAddresses = getFilteredAddresses();
+      return this.getMembersAddresses().stream().filter(address -> !filteredAddresses.contains(address)).collect(Collectors.toList());
    }
 
    /**
     * Send unicast message for specific address
     *
-    * @param content content of message
+    * @param content
+    *       content of message
     */
    public void sendToAddressAsync(Address address, Serializable content) throws Exception {
       this.dispatcher.sendMessage(new Message(address, Util.objectToByteBuffer(content)), ASYNC_OPTIONS);
@@ -130,11 +132,11 @@ public class JgroupsMessageSender {
    /**
     * Send unicast message for specific address
     *
-    * @param content content of message
+    * @param content
+    *       content of message
     */
    public <T> T sendToAddressSync(Address address, Serializable content) throws Exception {
       return this.dispatcher.sendMessage(new Message(address, Util.objectToByteBuffer(content)), SYNC_OPTIONS);
    }
-
 
 }

--- a/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/exception/SilverWareClusteringException.java
+++ b/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/exception/SilverWareClusteringException.java
@@ -2,7 +2,7 @@
  * -----------------------------------------------------------------------\
  * SilverWare
  *  
- * Copyright (C) 2010 - 2013 the original author or authors.
+ * Copyright (C) 2010 - 2016 the original author or authors.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,9 +74,9 @@ public class SilverWareClusteringException extends RuntimeException {
    @Override
    public String toString() {
       return "SilverWareClusteringException{" +
-              "reason=" + reason +
-              ", id=" + id +
-              ", super=" + super.toString() +
-              '}';
+            "reason=" + reason +
+            ", id=" + id +
+            ", super=" + super.toString() +
+            '}';
    }
 }

--- a/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/message/KnownImplementation.java
+++ b/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/message/KnownImplementation.java
@@ -2,7 +2,7 @@
  * -----------------------------------------------------------------------\
  * SilverWare
  *  
- * Copyright (C) 2010 - 2013 the original author or authors.
+ * Copyright (C) 2010 - 2016 the original author or authors.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,6 @@ public enum KnownImplementation {
    MICROSERVICE_REMOTE_CALL(MicroserviceRemoteCallResponse.class, MicroserviceRemoteCallRequest.class, MicroServiceRemoteCallResponder.class, MicroServiceRemoteCallResponder::new),
    MICROSERVICE_REMOTE_SEARCH(MicroserviceSearchResponse.class, MicroserviceMetaData.class, MicroserviceSearchResponder.class, MicroserviceSearchResponder::new);
 
-
    private final Class responseClass;
    private final Class messageClass;
    private final Class responderClass;
@@ -68,7 +67,6 @@ public enum KnownImplementation {
    public Class getResponderClass() {
       return responderClass;
    }
-
 
    public static Map<Class, Responder> initializeReponders(Context context) {
       return KNOWN_IMPLEMENTATIONS.stream().collect(Collectors.toMap(KnownImplementation::getMessageClass, v -> v.responderFactory.apply(context)));

--- a/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/message/request/MicroserviceRemoteCallRequest.java
+++ b/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/message/request/MicroserviceRemoteCallRequest.java
@@ -2,7 +2,7 @@
  * -----------------------------------------------------------------------\
  * SilverWare
  *  
- * Copyright (C) 2010 - 2013 the original author or authors.
+ * Copyright (C) 2010 - 2016 the original author or authors.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/message/request/RequestMessage.java
+++ b/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/message/request/RequestMessage.java
@@ -2,7 +2,7 @@
  * -----------------------------------------------------------------------\
  * SilverWare
  *  
- * Copyright (C) 2010 - 2013 the original author or authors.
+ * Copyright (C) 2010 - 2016 the original author or authors.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/message/responder/AbstractResponder.java
+++ b/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/message/responder/AbstractResponder.java
@@ -2,7 +2,7 @@
  * -----------------------------------------------------------------------\
  * SilverWare
  *  
- * Copyright (C) 2010 - 2013 the original author or authors.
+ * Copyright (C) 2010 - 2016 the original author or authors.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 package io.silverware.microservices.providers.cluster.internal.message.responder;
 
 import io.silverware.microservices.Context;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jgroups.Address;
@@ -28,8 +29,10 @@ import org.jgroups.Message;
 /**
  * Provides basic functionality and logging of messages.
  *
- * @param <C> message content type
- * @param <R> message response type
+ * @param <C>
+ *       message content type
+ * @param <R>
+ *       message response type
  * @author Slavomír Krupa (slavomir.krupa@gmail.com)
  */
 public abstract class AbstractResponder<C, R> implements Responder {
@@ -40,7 +43,6 @@ public abstract class AbstractResponder<C, R> implements Responder {
    protected static Logger log = LogManager.getLogger(AbstractResponder.class);
    protected Context context;
 
-
    public AbstractResponder(Context context) {
       this.context = context;
 
@@ -48,7 +50,9 @@ public abstract class AbstractResponder<C, R> implements Responder {
 
    @Override
    public final R processMessage(Message msg) {
-      log.trace("Processing msg: " + msg);
+      if (log.isDebugEnabled()) {
+         log.debug("Processing msg: " + msg);
+      }
       return doProcessMessage(msg.getSrc(), (C) msg.getObject());
    }
 

--- a/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/message/responder/MicroServiceRemoteCallResponder.java
+++ b/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/message/responder/MicroServiceRemoteCallResponder.java
@@ -2,7 +2,7 @@
  * -----------------------------------------------------------------------\
  * SilverWare
  *  
- * Copyright (C) 2010 - 2013 the original author or authors.
+ * Copyright (C) 2010 - 2016 the original author or authors.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,13 @@
  */
 package io.silverware.microservices.providers.cluster.internal.message.responder;
 
+import static io.silverware.microservices.providers.cluster.internal.exception.SilverWareClusteringException.SilverWareClusteringError.INVOCATION_EXCEPTION;
+
 import io.silverware.microservices.Context;
 import io.silverware.microservices.providers.cluster.internal.exception.SilverWareClusteringException;
-import static io.silverware.microservices.providers.cluster.internal.exception.SilverWareClusteringException.SilverWareClusteringError.INVOCATION_EXCEPTION;
 import io.silverware.microservices.providers.cluster.internal.message.request.MicroserviceRemoteCallRequest;
 import io.silverware.microservices.providers.cluster.internal.message.response.MicroserviceRemoteCallResponse;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jgroups.Address;

--- a/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/message/responder/Responder.java
+++ b/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/message/responder/Responder.java
@@ -2,7 +2,7 @@
  * -----------------------------------------------------------------------\
  * SilverWare
  *  
- * Copyright (C) 2010 - 2013 the original author or authors.
+ * Copyright (C) 2010 - 2016 the original author or authors.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,8 @@ import org.jgroups.Message;
 /**
  * Interface specifying processor class for responses
  *
- * @param <R> response class
+ * @param <R>
+ *       response class
  * @author Slavomír Krupa (slavomir.krupa@gmail.com)
  */
 public interface Responder<R> {

--- a/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/message/response/MicroserviceRemoteCallResponse.java
+++ b/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/message/response/MicroserviceRemoteCallResponse.java
@@ -2,7 +2,7 @@
  * -----------------------------------------------------------------------\
  * SilverWare
  *  
- * Copyright (C) 2010 - 2013 the original author or authors.
+ * Copyright (C) 2010 - 2016 the original author or authors.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/message/response/MicroserviceSearchResponse.java
+++ b/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/message/response/MicroserviceSearchResponse.java
@@ -2,7 +2,7 @@
  * -----------------------------------------------------------------------\
  * SilverWare
  *  
- * Copyright (C) 2010 - 2013 the original author or authors.
+ * Copyright (C) 2010 - 2016 the original author or authors.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,11 @@ public class MicroserviceSearchResponse implements Serializable {
     * This enum represents result of a search on a cluster
     */
    public enum Result {
-      FOUND(true), NOT_FOUND(false), WRONG_VESION(false);
+      FOUND(true),
+      NOT_FOUND(false),
+      WRONG_VERSION(false),
+      EXCEPTION_THROWN_DURING_LOOKUP(false),
+      MULTIPLE_IMPLEMENTATIONS_FOUND(false);
       private boolean usable;
 
       Result(boolean canBeUsed) {
@@ -45,6 +49,11 @@ public class MicroserviceSearchResponse implements Serializable {
 
    private final Integer handle;
    private final Result result;
+
+   public MicroserviceSearchResponse(final Result result) {
+      handle = null;
+      this.result = result;
+   }
 
    public MicroserviceSearchResponse(Integer handle, Result result) {
       this.handle = handle;

--- a/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/message/response/ResponseMessage.java
+++ b/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/message/response/ResponseMessage.java
@@ -2,7 +2,7 @@
  * -----------------------------------------------------------------------\
  * SilverWare
  *  
- * Copyright (C) 2010 - 2013 the original author or authors.
+ * Copyright (C) 2010 - 2016 the original author or authors.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/util/FutureListenerHelper.java
+++ b/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/util/FutureListenerHelper.java
@@ -17,9 +17,10 @@
  * limitations under the License.
  * -----------------------------------------------------------------------/
  */
-package io.silverware.microservices.providers.cluster.internal;
+package io.silverware.microservices.providers.cluster.internal.util;
 
 import io.silverware.microservices.providers.cluster.internal.message.response.MicroserviceSearchResponse;
+
 import org.jgroups.util.FutureListener;
 import org.jgroups.util.RspList;
 
@@ -33,7 +34,7 @@ import java.util.function.Consumer;
  * @author Slavomír Krupa (slavomir.krupa@gmail.com)
  */
 public class FutureListenerHelper<T> implements FutureListener<RspList<MicroserviceSearchResponse>> {
-   private Consumer<Future<RspList<MicroserviceSearchResponse>>> consumer;
+   private final Consumer<Future<RspList<MicroserviceSearchResponse>>> consumer;
 
    public FutureListenerHelper(Consumer<Future<RspList<MicroserviceSearchResponse>>> consumer) {
       this.consumer = consumer;

--- a/cluster-microservice-provider/src/test/java/io/silverware/microservices/providers/cluster/ClusterMicroserviceProviderTest.java
+++ b/cluster-microservice-provider/src/test/java/io/silverware/microservices/providers/cluster/ClusterMicroserviceProviderTest.java
@@ -2,7 +2,7 @@
  * -----------------------------------------------------------------------\
  * SilverWare
  *  
- * Copyright (C) 2010 - 2013 the original author or authors.
+ * Copyright (C) 2010 - 2016 the original author or authors.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,15 +19,14 @@
  */
 package io.silverware.microservices.providers.cluster;
 
-import io.silverware.microservices.providers.cluster.internal.JgroupsMessageSender;
 import static io.silverware.microservices.providers.cluster.internal.RemoteServiceHandleStoreTest.META_DATA;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.silverware.microservices.providers.cluster.internal.JgroupsMessageSender;
 import io.silverware.microservices.providers.cluster.internal.message.response.MicroserviceSearchResponse;
 import io.silverware.microservices.silver.cluster.RemoteServiceHandlesStore;
 import io.silverware.microservices.silver.cluster.ServiceHandle;
-import mockit.Expectations;
-import mockit.Injectable;
-import mockit.Tested;
-import static org.assertj.core.api.Assertions.assertThat;
+
 import org.jgroups.Address;
 import org.jgroups.util.FutureListener;
 import org.jgroups.util.RspList;
@@ -35,9 +34,14 @@ import org.testng.annotations.Test;
 
 import java.util.Set;
 
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Tested;
+
 /**
  * Test for ClusterMicroserviceProvider
- *   @author Slavomír Krupa (slavomir.krupa@gmail.com)
+ *
+ * @author Slavomír Krupa (slavomir.krupa@gmail.com)
  */
 public class ClusterMicroserviceProviderTest {
 
@@ -50,20 +54,15 @@ public class ClusterMicroserviceProviderTest {
    @Injectable
    private JgroupsMessageSender sender;
 
-
    @Test
    public void testLookupMicroservice() throws Exception {
       Set<ServiceHandle> mockHandles = Util.createSetFrom(Util.createHandle("1"), Util.createHandle("2"));
       Set<Object> services = Util.createSetFrom(new Object(), new Object());
 
-
       new Expectations() {{
          sender.sendToClusterAsync(META_DATA, (Set<Address>) any, (FutureListener<RspList<MicroserviceSearchResponse>>) any);
          times = 1;
          result = mockHandles;
-         // TODO: 9/9/16 test this again
-//         store.addHandles(META_DATA, mockHandles);
-//         times = 1;
          store.getServices(META_DATA);
          result = services;
          times = 1;
@@ -77,8 +76,8 @@ public class ClusterMicroserviceProviderTest {
    public void testLookupLocalMicroservice() throws Exception {
       Set<Object> objects = clusterMicroserviceProvider.lookupLocalMicroservice(META_DATA);
       assertThat(objects)
-              .isNotNull()
-              .isEmpty();
+            .isNotNull()
+            .isEmpty();
 
    }
 }

--- a/cluster-microservice-provider/src/test/java/io/silverware/microservices/providers/cluster/Util.java
+++ b/cluster-microservice-provider/src/test/java/io/silverware/microservices/providers/cluster/Util.java
@@ -2,7 +2,7 @@
  * -----------------------------------------------------------------------\
  * SilverWare
  *  
- * Copyright (C) 2010 - 2013 the original author or authors.
+ * Copyright (C) 2010 - 2016 the original author or authors.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,5 @@ public class Util {
    public static <T> Set<T> createSetFrom(T... components) {
       return new HashSet<>(Arrays.asList(components));
    }
-
 
 }

--- a/cluster-microservice-provider/src/test/java/io/silverware/microservices/providers/cluster/internal/JgroupsMessageReceiverTest.java
+++ b/cluster-microservice-provider/src/test/java/io/silverware/microservices/providers/cluster/internal/JgroupsMessageReceiverTest.java
@@ -2,7 +2,7 @@
  * -----------------------------------------------------------------------\
  * SilverWare
  *  
- * Copyright (C) 2010 - 2013 the original author or authors.
+ * Copyright (C) 2010 - 2016 the original author or authors.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,12 @@
  */
 package io.silverware.microservices.providers.cluster.internal;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import io.silverware.microservices.providers.cluster.internal.exception.SilverWareClusteringException;
 import io.silverware.microservices.providers.cluster.internal.message.responder.Responder;
 import io.silverware.microservices.silver.cluster.RemoteServiceHandlesStore;
-import mockit.Capturing;
-import mockit.Verifications;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.jgroups.Message;
 import org.jgroups.blocks.MessageDispatcher;
 import org.testng.annotations.BeforeMethod;
@@ -32,6 +32,9 @@ import org.testng.annotations.Test;
 
 import java.util.HashMap;
 import java.util.UUID;
+
+import mockit.Capturing;
+import mockit.Verifications;
 
 /**
  * Test for a receiver
@@ -53,7 +56,6 @@ public class JgroupsMessageReceiverTest {
 
    @BeforeMethod
    public void setUp() throws Exception {
-
 
    }
 
@@ -77,7 +79,6 @@ public class JgroupsMessageReceiverTest {
          times = 0;
       }};
    }
-
 
    @Test
    public void testReceiveWithUnknownClassThrowsException() throws Exception {

--- a/cluster-microservice-provider/src/test/java/io/silverware/microservices/providers/cluster/internal/JgroupsMessageSenderTest.java
+++ b/cluster-microservice-provider/src/test/java/io/silverware/microservices/providers/cluster/internal/JgroupsMessageSenderTest.java
@@ -2,7 +2,7 @@
  * -----------------------------------------------------------------------\
  * SilverWare
  *  
- * Copyright (C) 2010 - 2013 the original author or authors.
+ * Copyright (C) 2010 - 2016 the original author or authors.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,9 @@
  */
 package io.silverware.microservices.providers.cluster.internal;
 
-import mockit.Capturing;
-import mockit.Deencapsulation;
-import mockit.Expectations;
-import mockit.Verifications;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.jgroups.Address;
 import org.jgroups.Message;
 import org.jgroups.blocks.MessageDispatcher;
@@ -37,13 +34,17 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
+import mockit.Capturing;
+import mockit.Deencapsulation;
+import mockit.Expectations;
+import mockit.Verifications;
+
 /**
  * Test for JgroupsMessageSender
  *
  * @author Slavomír Krupa (slavomir.krupa@gmail.com)
  */
 public class JgroupsMessageSenderTest {
-
 
    @Capturing
    private MessageDispatcher dispatcher;
@@ -64,7 +65,7 @@ public class JgroupsMessageSenderTest {
    @Test
    public void testSendToClusterSync() throws Exception {
       new Expectations(jgroupsMessageSender) {{
-         Deencapsulation.invoke(jgroupsMessageSender, "getMembersAdresses");
+         Deencapsulation.invoke(jgroupsMessageSender, "getMembersAddresses");
          result = Collections.emptyList();
       }};
       String id = UUID.randomUUID().toString();
@@ -111,6 +112,5 @@ public class JgroupsMessageSenderTest {
       }};
 
    }
-
 
 }

--- a/cluster-microservice-provider/src/test/java/io/silverware/microservices/providers/cluster/internal/RemoteServiceHandleStoreTest.java
+++ b/cluster-microservice-provider/src/test/java/io/silverware/microservices/providers/cluster/internal/RemoteServiceHandleStoreTest.java
@@ -2,7 +2,7 @@
  * -----------------------------------------------------------------------\
  * SilverWare
  *  
- * Copyright (C) 2010 - 2013 the original author or authors.
+ * Copyright (C) 2010 - 2016 the original author or authors.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,14 @@
  */
 package io.silverware.microservices.providers.cluster.internal;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.silverware.microservices.MicroserviceMetaData;
 import io.silverware.microservices.providers.cluster.Util;
 import io.silverware.microservices.silver.cluster.LocalServiceHandle;
 import io.silverware.microservices.silver.cluster.RemoteServiceHandlesStore;
 import io.silverware.microservices.silver.cluster.ServiceHandle;
+
 import org.testng.annotations.Test;
 
 import java.lang.annotation.Annotation;
@@ -31,20 +34,18 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 /**
  * Basic Unit tests for remote handles store
  *
  * @author Slavomír Krupa (slavomir.krupa@gmail.com)
  */
 public class RemoteServiceHandleStoreTest {
+   private static final String VERSION = "1.0.0";
 
    private static final Set<Annotation> ANNOTATIONS = new HashSet<>(Arrays.asList(RemoteServiceHandleStoreTest.class.getClass().getAnnotations()));
 
-   public static final MicroserviceMetaData META_DATA = new MicroserviceMetaData(RemoteServiceHandleStoreTest.class.getName(), RemoteServiceHandleStoreTest.class, ANNOTATIONS, ANNOTATIONS);
+   public static final MicroserviceMetaData META_DATA = new MicroserviceMetaData(RemoteServiceHandleStoreTest.class.getName(), RemoteServiceHandleStoreTest.class, ANNOTATIONS, ANNOTATIONS, VERSION, VERSION);
    public static final LocalServiceHandle SERVICE_HANDLE = Util.createHandle("host");
-
 
    @Test
    public void addSingleHandle() {

--- a/http-invoker-microservice-provider/src/test/java/io/silverware/microservices/providers/http/invoker/HttpInvokerMicroserviceProviderTest.java
+++ b/http-invoker-microservice-provider/src/test/java/io/silverware/microservices/providers/http/invoker/HttpInvokerMicroserviceProviderTest.java
@@ -1,7 +1,5 @@
 package io.silverware.microservices.providers.http.invoker;
 
-import com.cedarsoftware.util.io.JsonReader;
-import com.cedarsoftware.util.io.JsonWriter;
 import io.silverware.microservices.MicroserviceMetaData;
 import io.silverware.microservices.annotations.Microservice;
 import io.silverware.microservices.providers.cdi.CdiMicroserviceProvider;
@@ -13,6 +11,9 @@ import io.silverware.microservices.silver.cluster.Invocation;
 import io.silverware.microservices.silver.cluster.LocalServiceHandle;
 import io.silverware.microservices.util.BootUtil;
 import io.silverware.microservices.util.Utils;
+
+import com.cedarsoftware.util.io.JsonReader;
+import com.cedarsoftware.util.io.JsonWriter;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -31,6 +32,7 @@ import java.util.Map;
  * @author <a href="mailto:marvenec@gmail.com">Martin Večeřa</a>
  */
 public class HttpInvokerMicroserviceProviderTest {
+   private static final String VERSION = "1.0.0";
 
    private HttpInvokerSilverService httpInvokerSilverService = null;
 
@@ -60,7 +62,7 @@ public class HttpInvokerMicroserviceProviderTest {
       con.setDoOutput(true);
       con.connect();
 
-      final MicroserviceMetaData metaData = new MicroserviceMetaData("sumService", SumService.class, Collections.emptySet());
+      final MicroserviceMetaData metaData = new MicroserviceMetaData("sumService", SumService.class, Collections.emptySet(), Collections.emptySet(), VERSION, VERSION);
       JsonWriter jsonWriter = new JsonWriter(con.getOutputStream());
       jsonWriter.write(metaData);
 
@@ -72,7 +74,7 @@ public class HttpInvokerMicroserviceProviderTest {
       con.disconnect();
 
       final LocalServiceHandle handle = handles.get(0);
-      long l = (Long) handle.invoke(bootUtil.getContext(), "sum", new Class[] {short.class, int.class}, new Object[] {(short) 3, 4});
+      long l = (Long) handle.invoke(bootUtil.getContext(), "sum", new Class[] { short.class, int.class }, new Object[] { (short) 3, 4 });
       Assert.assertEquals(l, 7L);
 
       con = (HttpURLConnection) new URL(urlBase + "invoke").openConnection();
@@ -81,7 +83,7 @@ public class HttpInvokerMicroserviceProviderTest {
       con.setDoOutput(true);
       con.connect();
 
-      Invocation invocation = new Invocation(handles.get(0).getHandle(), "sum", new Class[] {short.class, int.class}, new Object[] {(short) 3, 4});
+      Invocation invocation = new Invocation(handles.get(0).getHandle(), "sum", new Class[] { short.class, int.class }, new Object[] { (short) 3, 4 });
       jsonWriter = new JsonWriter(con.getOutputStream());
       jsonWriter.write(invocation);
       jsonReader = new JsonReader(con.getInputStream());
@@ -97,7 +99,7 @@ public class HttpInvokerMicroserviceProviderTest {
       con.setDoOutput(true);
       con.connect();
 
-      invocation = new Invocation(handles.get(0).getHandle(), "allTypes", new Class[] {byte.class, short.class, int.class, long.class, float.class, double.class, boolean.class, char.class}, new Object[] {Byte.MAX_VALUE, Short.MAX_VALUE, Integer.MAX_VALUE, Long.MAX_VALUE, Float.MIN_VALUE, Double.MIN_VALUE, true, 'c'});
+      invocation = new Invocation(handles.get(0).getHandle(), "allTypes", new Class[] { byte.class, short.class, int.class, long.class, float.class, double.class, boolean.class, char.class }, new Object[] { Byte.MAX_VALUE, Short.MAX_VALUE, Integer.MAX_VALUE, Long.MAX_VALUE, Float.MIN_VALUE, Double.MIN_VALUE, true, 'c' });
 
       jsonWriter = new JsonWriter(con.getOutputStream());
       jsonWriter.write(invocation);
@@ -114,7 +116,7 @@ public class HttpInvokerMicroserviceProviderTest {
       con.setDoOutput(true);
       con.connect();
 
-      invocation = new Invocation(handles.get(0).getHandle(), "allTypes2", new Class[] {Byte.class, Short.class, Integer.class, Long.class, Float.class, Double.class, Boolean.class, Character.class}, new Object[] {Byte.MAX_VALUE, Short.MAX_VALUE, Integer.MAX_VALUE, Long.MAX_VALUE, Float.MIN_VALUE, Double.MIN_VALUE, true, 'c'});
+      invocation = new Invocation(handles.get(0).getHandle(), "allTypes2", new Class[] { Byte.class, Short.class, Integer.class, Long.class, Float.class, Double.class, Boolean.class, Character.class }, new Object[] { Byte.MAX_VALUE, Short.MAX_VALUE, Integer.MAX_VALUE, Long.MAX_VALUE, Float.MIN_VALUE, Double.MIN_VALUE, true, 'c' });
 
       jsonWriter = new JsonWriter(con.getOutputStream());
       jsonWriter.write(invocation);
@@ -133,7 +135,7 @@ public class HttpInvokerMicroserviceProviderTest {
 
       MagicBox box = new MagicBox();
 
-      invocation = new Invocation(handles.get(0).getHandle(), "doMagic", new Class[] {MagicBox.class}, new Object[] {box});
+      invocation = new Invocation(handles.get(0).getHandle(), "doMagic", new Class[] { MagicBox.class }, new Object[] { box });
 
       jsonWriter = new JsonWriter(con.getOutputStream());
       jsonWriter.write(invocation);

--- a/microservices-bom/pom.xml
+++ b/microservices-bom/pom.xml
@@ -76,6 +76,7 @@
       <version.jmockit>1.8</version.jmockit>
       <version.assertj>3.5.2</version.assertj>
       <version.org.jboss.resteasy>3.0.17.Final</version.org.jboss.resteasy>
+      <version.sem.ver>2.0.1</version.sem.ver>
       <java.level>1.8</java.level>
    </properties>
    <dependencyManagement>
@@ -349,6 +350,11 @@
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
             <version>${version.org.jboss.resteasy}</version>
+         </dependency>
+         <dependency>
+            <groupId>com.vdurmont</groupId>
+            <artifactId>semver4j</artifactId>
+            <version>${version.sem.ver}</version>
          </dependency>
       </dependencies>
    </dependencyManagement>

--- a/microservices/pom.xml
+++ b/microservices/pom.xml
@@ -21,6 +21,15 @@
          <groupId>com.cedarsoftware</groupId>
          <artifactId>json-io</artifactId>
       </dependency>
+      <dependency>
+         <groupId>com.vdurmont</groupId>
+         <artifactId>semver4j</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.assertj</groupId>
+         <artifactId>assertj-core</artifactId>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
    <build>
       <plugins>

--- a/microservices/src/main/java/io/silverware/microservices/Context.java
+++ b/microservices/src/main/java/io/silverware/microservices/Context.java
@@ -25,6 +25,7 @@ import io.silverware.microservices.silver.ProvidingSilverService;
 import io.silverware.microservices.silver.SilverService;
 import io.silverware.microservices.silver.cluster.LocalServiceHandle;
 import io.silverware.microservices.silver.cluster.RemoteServiceHandlesStore;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -204,7 +205,7 @@ public class Context {
     * @return A list of {@link LocalServiceHandle Service Handles} that meet the specified query.
     */
    public List<LocalServiceHandle> assureHandles(final MicroserviceMetaData metaData) {
-      List<LocalServiceHandle> result = inboundHandles.stream().filter(serviceHandle -> serviceHandle.getQuery().equals(metaData)).collect(Collectors.toList());
+      List<LocalServiceHandle> result = inboundHandles.stream().filter(serviceHandle -> serviceHandle.getMetaData().equals(metaData)).collect(Collectors.toList());
       Set<Object> microservices = lookupLocalMicroservice(metaData);
       Set<Object> haveHandles = result.stream().map(LocalServiceHandle::getProxy).collect(Collectors.toSet());
       microservices.removeAll(haveHandles);

--- a/microservices/src/main/java/io/silverware/microservices/silver/cluster/LocalServiceHandle.java
+++ b/microservices/src/main/java/io/silverware/microservices/silver/cluster/LocalServiceHandle.java
@@ -19,11 +19,12 @@
  */
 package io.silverware.microservices.silver.cluster;
 
-import com.cedarsoftware.util.io.JsonReader;
-import com.cedarsoftware.util.io.JsonWriter;
 import io.silverware.microservices.Context;
 import io.silverware.microservices.MicroserviceMetaData;
 import io.silverware.microservices.silver.HttpInvokerSilverService;
+
+import com.cedarsoftware.util.io.JsonReader;
+import com.cedarsoftware.util.io.JsonWriter;
 
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -37,7 +38,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * @author <a href="mailto:marvenec@gmail.com">Martin Večeřa</a>
  */
-// TODO: 9/8/16 Remove remote proxy and htpp invoker - it should be in separated object
+// TODO: 9/8/16 Remove htpp invoker - it should be in separated object
 public class LocalServiceHandle implements ServiceHandle {
 
    private static final transient AtomicInteger handleSource = new AtomicInteger(0);
@@ -75,7 +76,7 @@ public class LocalServiceHandle implements ServiceHandle {
       return host;
    }
 
-   public MicroserviceMetaData getQuery() {
+   public MicroserviceMetaData getMetaData() {
       return query;
    }
 

--- a/microservices/src/main/java/io/silverware/microservices/silver/cluster/RemoteServiceHandlesStore.java
+++ b/microservices/src/main/java/io/silverware/microservices/silver/cluster/RemoteServiceHandlesStore.java
@@ -70,7 +70,7 @@ public class RemoteServiceHandlesStore {
    /**
     * Removes all handles which are not mentioned in available nodes
     *
-    * @param availableNodes adresses of available nodes
+    * @param availableNodes addresses of available nodes
     */
    public void keepHandlesFor(Set<String> availableNodes) {
       outboundHandles.forEach((metaData, serviceHandles) -> {

--- a/microservices/src/main/java/io/silverware/microservices/silver/services/LookupStrategyFactory.java
+++ b/microservices/src/main/java/io/silverware/microservices/silver/services/LookupStrategyFactory.java
@@ -23,6 +23,7 @@ import io.silverware.microservices.Context;
 import io.silverware.microservices.MicroserviceMetaData;
 import io.silverware.microservices.annotations.InvocationPolicy;
 import io.silverware.microservices.silver.services.lookup.RandomRobinLookupStrategy;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -38,7 +39,7 @@ public class LookupStrategyFactory {
    /**
     * Logger.
     */
-   private static Logger log = LogManager.getLogger(LookupStrategyFactory.class);
+   private static final Logger log = LogManager.getLogger(LookupStrategyFactory.class);
 
    /**
     * Returns strategy based on given parameters
@@ -68,7 +69,6 @@ public class LookupStrategyFactory {
       }
 
       if (strategy == null) {
-         // TODO: 9/9/16 this should be discussed
          strategy = new RandomRobinLookupStrategy();
          strategy.initialize(context, metaData, options);
       }

--- a/microservices/src/main/java/io/silverware/microservices/util/Utils.java
+++ b/microservices/src/main/java/io/silverware/microservices/util/Utils.java
@@ -52,7 +52,7 @@ public class Utils {
     * Logs a shutdown message with the given exception.
     *
     * @param log A logger where to log the message to.
-    * @param ie An exception causing the shutdown.
+    * @param ie  An exception causing the shutdown.
     */
    public static void shutdownLog(final Logger log, final InterruptedException ie) {
       log.info("Execution interrupted, exiting.");
@@ -65,7 +65,7 @@ public class Utils {
     * Waits for the URL to become available.
     *
     * @param urlString The URL to check for.
-    * @param code The expected HTTP response code.
+    * @param code      The expected HTTP response code.
     * @return Returns true if the URL was available, false otherwise.
     * @throws Exception When it was not possible to check the URL.
     */
@@ -109,7 +109,7 @@ public class Utils {
    /**
     * Gets the manifest entry for the given class.
     *
-    * @param clazz The class I want to obtain entry for.
+    * @param clazz     The class I want to obtain entry for.
     * @param entryName The name of the entry to obtain.
     * @return The entry from manifest, null if there is no such entry or the manifest file does not exists.
     * @throws IOException When it was not possible to get the manifest file.
@@ -130,41 +130,6 @@ public class Utils {
       return null;
    }
 
-   /**
-    * Gets the class implementation version from manifest.
-    *
-    * @param clazz The class I want to obtain version of.
-    * @return The class specification version from manifest, null if there is no version information present or the manifest file does not exists.
-    */
-   public static String getClassImplVersion(final Class clazz) {
-      try {
-         return getManifestEntry(clazz, "Implementation-Version");
-      } catch (IOException ioe) {
-         if (log.isDebugEnabled()) {
-            log.debug("Cannot obtain version for class {}.", clazz.getName());
-         }
-      }
-
-      return null;
-   }
-
-   /**
-    * Gets the class specification version from manifest.
-    *
-    * @param clazz The class I want to obtain version of.
-    * @return The class specification version from manifest, null if there is no version information present or the manifest file does not exists.
-    */
-   public static String getClassSpecVersion(final Class clazz) {
-      try {
-         return getManifestEntry(clazz, "Specification-Version");
-      } catch (IOException ioe) {
-         if (log.isDebugEnabled()) {
-            log.debug("Cannot obtain version for class {}.", clazz.getName());
-         }
-      }
-
-      return null;
-   }
 
    /**
     * Do the best to sleep for the given time. Ignores {@link InterruptedException}.

--- a/microservices/src/main/java/io/silverware/microservices/util/VersionComparator.java
+++ b/microservices/src/main/java/io/silverware/microservices/util/VersionComparator.java
@@ -1,0 +1,109 @@
+/*
+ * -----------------------------------------------------------------------\
+ * SilverWare
+ *  
+ * Copyright (C) 2010 - 2016 the original author or authors.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------/
+ */
+package io.silverware.microservices.util;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+import com.vdurmont.semver4j.Semver;
+import com.vdurmont.semver4j.SemverException;
+
+/**
+ * Adapter for a Java Sem-Ver
+ * Created because the project is in beta and the api can change.
+ * This implementation is using <a href="https://github.com/npm/node-semver">NPM versioning rules.</a>
+ * implemented in library <a href="https://github.com/vdurmont/semver4j">Semantic Versioning home page.</a>
+ *
+ * Be aware:
+ * If a version has a prerelease tag (for example, 1.2.3-alpha.3) then it will only be allowed
+ * to satisfy comparator sets if at least one comparator with the same [major, minor, patch] tuple also has a prerelease tag.
+ *
+ * @author Slavomír Krupa (slavomir.krupa@gmail.com)
+ */
+public class VersionComparator {
+
+   private final Semver semVersion;
+
+   private VersionComparator(String version) {
+      try {
+
+         if (isNullOrEmpty(version)) {
+            this.semVersion = null;
+         } else {
+            /*
+              build version must be appended to x.y.z format number otherwise the comparision wont work.
+              here we are creating correct string for comparision.
+             */
+            Semver builtVersion = new Semver(version, Semver.SemverType.NPM);
+            if (builtVersion.getMinor() == null && builtVersion.getPatch() == null) {
+               int indexOfMinorVersion = ("" + builtVersion.getMajor()).length();
+               version = buildVersionWithPatch(version, indexOfMinorVersion, ".0.0");
+            } else if (builtVersion.getPatch() == null) {
+               int indexOfPatchVersion = ("." + builtVersion.getMinor() + builtVersion.getMajor()).length();
+               version = buildVersionWithPatch(version, indexOfPatchVersion, ".0");
+            }
+            this.semVersion = new Semver(version, Semver.SemverType.NPM);
+         }
+
+      } catch (SemverException e) {
+         throw new IllegalArgumentException(e);
+      }
+   }
+
+   /**
+    * Factory method which creates an instance of this class.
+    *
+    * @param version
+    *       semVersion for which object should be created when or empty provided then it won't satisfy any expression
+    * @return created object
+    * @throws IllegalArgumentException
+    *       when the format of the semVersion is wrong
+    */
+   public static VersionComparator forVersion(String version) {
+      return new VersionComparator(version);
+   }
+
+   /**
+    * Compare semVersion of a object and the expression.
+    *
+    * @param expression
+    *       the expression specifying supported versions
+    * @return true when expression is null, false when semVersion in object is null and result of a @{@link Semver}.satisfies() otherwise.
+    * @throws IllegalArgumentException
+    *       when the format of a expression is wrong
+    */
+   public boolean satisfies(String expression) {
+      if (isNullOrEmpty(expression)) {
+         return true;
+      }
+      if (semVersion == null) {
+         return false;
+      }
+      try {
+         return semVersion.satisfies(expression);
+      } catch (SemverException e) {
+         throw new IllegalArgumentException(e);
+      }
+   }
+
+   private static String buildVersionWithPatch(String originalValue, int index, String missingVersions) {
+      return originalValue.substring(0, index) + missingVersions + originalValue.substring(index, originalValue.length());
+   }
+
+}

--- a/microservices/src/test/java/io/silverware/microservices/util/VersionComparatorTest.java
+++ b/microservices/src/test/java/io/silverware/microservices/util/VersionComparatorTest.java
@@ -1,0 +1,84 @@
+/*
+ * -----------------------------------------------------------------------\
+ * SilverWare
+ *
+ * Copyright (C) 2010 - 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------/
+ */
+package io.silverware.microservices.util;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * This test shall demonstrate functionality of version specifying
+ *
+ * @author Slavomír Krupa (slavomir.krupa@gmail.com)
+ */
+public class VersionComparatorTest {
+   private static final String VERSION = "1.2.3";
+
+   private static final String MINOR_VERSION_SNAPSHOT = "1.2-SNAPSHOT";
+   private static final String MAJOR_VERSION_SNAPSHOT = "1-SNAPSHOT";
+
+   public static final String DESCRIPTION = "Version %s should%sbe satisfied by a condition %s.";
+   public static final String SUCCESS_MAJOR_SNAPSHOT = "successMajorSnapshot";
+   public static final String SUCCESS_LESS_DIGITS = "successLessDigits";
+   public static final String FAIL = "fail";
+   public static final String SUCCESS = "success";
+
+   @DataProvider(name = SUCCESS)
+   public static Object[][] successVersions() {
+      return new Object[][] { { VERSION }, { "1.*" }, { "1.2.x" }, { "1.X" }, { "~1.2" }, { VERSION + "-" + VERSION }, { "^1" }, { "^" + VERSION } };
+   }
+
+   @Test(dataProvider = SUCCESS)
+   public void testSatisfiesConditionSuccess(String condition) throws Exception {
+      assertThat(VersionComparator.forVersion(VERSION).satisfies(condition)).as(DESCRIPTION, VERSION, " ", condition).isTrue();
+   }
+
+   @DataProvider(name = FAIL)
+   public static Object[][] failVersions() {
+      return new Object[][] { { "1.2.5" }, { "1.0.*" }, { "1.1.x" }, { "1.3.X" }, { "~1.3" }, { "1.2.4-1.4.0" }, { "^2" }, { "^1.2.4" } };
+   }
+
+   @Test(dataProvider = FAIL)
+   public void testSatisfiesConditionFails(String condition) throws Exception {
+      assertThat(VersionComparator.forVersion(VERSION).satisfies(condition)).as(DESCRIPTION, VERSION, " not ", condition).isFalse();
+   }
+
+   @DataProvider(name = SUCCESS_LESS_DIGITS)
+   public static Object[][] successVersionsLessDigits() {
+      return new Object[][] { { MINOR_VERSION_SNAPSHOT }, { "~1.2-SNAPSHOT" }, { "1.2.x-SNAPSHOT" }, { "" } };
+   }
+
+   @Test(dataProvider = SUCCESS_LESS_DIGITS)
+   public void testSatisfiesConditionWithLessDigitsSuccess(String condition) throws Exception {
+      assertThat(VersionComparator.forVersion(MINOR_VERSION_SNAPSHOT).satisfies(condition)).as(DESCRIPTION, MINOR_VERSION_SNAPSHOT, " ", condition).isTrue();
+   }
+
+   @DataProvider(name = SUCCESS_MAJOR_SNAPSHOT)
+   public static Object[][] successVersionsMajorSnapshot() {
+      return new Object[][] { { MAJOR_VERSION_SNAPSHOT }, { "~1-SNAPSHOT" }, { "1.x-SNAPSHOT" }, { "" }, { "^1-SNAPSHOT" }, { "1-SNAPSHOT" } };
+   }
+
+   @Test(dataProvider = SUCCESS_MAJOR_SNAPSHOT)
+   public void testSatisfiesConditionMajorSnapshotSuccess(String condition) throws Exception {
+      assertThat(VersionComparator.forVersion(MAJOR_VERSION_SNAPSHOT).satisfies(condition)).as(DESCRIPTION, MAJOR_VERSION_SNAPSHOT, " ", condition).isTrue();
+   }
+
+}


### PR DESCRIPTION
  - Versioning uses semver4j from https://github.com/vdurmont/semver4j
    in npm mode. It allows wider range of queries to be executed and
    rules for the version format is not so strict.
    i.e - major and patch versions are not required.
    see -  https://github.com/npm/node-semver for more information.
    Process of resolving versions is described in VersionResolver.
  - Fix for cluster when main node of the cluster fails.
  - Cluster lookup now provides more clear information
    about a result of a lookup.
