### PR TITLE
Update Undertow version to 1.4.4.Final

### DIFF
--- a/microservices-bom/pom.xml
+++ b/microservices-bom/pom.xml
@@ -66,7 +66,7 @@
       <version.commons.lang>3.4</version.commons.lang>
       <version.findbugs>1.3.2</version.findbugs>
       <version.javassist>3.20.0-GA</version.javassist>
-      <version.undertow>1.3.11.Final</version.undertow>
+      <version.undertow>1.4.4.Final</version.undertow>
       <version.jolokia>1.3.2</version.jolokia>
       <version.jackson>2.6.4</version.jackson>
       <version.vertx>3.2.0</version.vertx>


### PR DESCRIPTION
[UNDERTOW-601](https://issues.jboss.org/browse/UNDERTOW-601) which caused NPE while a servlet was being deployed is fixed in this version.