### PR TITLE
Add RoundRobinLookupStrategy and change other strategies

### DIFF
--- a/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/JgroupsMessageSender.java
+++ b/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/JgroupsMessageSender.java
@@ -110,7 +110,7 @@ public class JgroupsMessageSender {
       sendToClusterAsync(content, Collections.emptySet(), listener);
    }
 
-   private List<Address> getMembersAddresses() {
+   List<Address> getMembersAddresses() {
       return this.dispatcher.getChannel().getView().getMembers();
    }
 

--- a/cluster-microservice-provider/src/test/java/io/silverware/microservices/providers/cluster/internal/JgroupsMessageSenderTest.java
+++ b/cluster-microservice-provider/src/test/java/io/silverware/microservices/providers/cluster/internal/JgroupsMessageSenderTest.java
@@ -35,8 +35,8 @@ import java.util.List;
 import java.util.UUID;
 
 import mockit.Capturing;
-import mockit.Deencapsulation;
 import mockit.Expectations;
+import mockit.Tested;
 import mockit.Verifications;
 
 /**
@@ -48,6 +48,7 @@ public class JgroupsMessageSenderTest {
 
    @Capturing
    private MessageDispatcher dispatcher;
+   @Tested
    private JgroupsMessageSender jgroupsMessageSender;
 
    private Address address = new org.jgroups.util.UUID();
@@ -65,7 +66,7 @@ public class JgroupsMessageSenderTest {
    @Test
    public void testSendToClusterSync() throws Exception {
       new Expectations(jgroupsMessageSender) {{
-         Deencapsulation.invoke(jgroupsMessageSender, "getMembersAddresses");
+         jgroupsMessageSender.getMembersAddresses();
          result = Collections.emptyList();
       }};
       String id = UUID.randomUUID().toString();

--- a/microservices-bom/pom.xml
+++ b/microservices-bom/pom.xml
@@ -73,7 +73,7 @@
       <version.jsonio>4.3.0</version.jsonio>
       <version.beanutils>1.9.2</version.beanutils>
       <version.drools>6.3.0.Final</version.drools>
-      <version.jmockit>1.8</version.jmockit>
+      <version.jmockit>1.29</version.jmockit>
       <version.assertj>3.5.2</version.assertj>
       <version.org.jboss.resteasy>3.0.17.Final</version.org.jboss.resteasy>
       <version.sem.ver>2.0.1</version.sem.ver>

--- a/microservices/pom.xml
+++ b/microservices/pom.xml
@@ -30,6 +30,11 @@
          <artifactId>assertj-core</artifactId>
          <scope>test</scope>
       </dependency>
+      <dependency>
+         <groupId>org.jmockit</groupId>
+         <artifactId>jmockit</artifactId>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
    <build>
       <plugins>

--- a/microservices/src/main/java/io/silverware/microservices/silver/services/LookupStrategyFactory.java
+++ b/microservices/src/main/java/io/silverware/microservices/silver/services/LookupStrategyFactory.java
@@ -2,7 +2,7 @@
  * -----------------------------------------------------------------------\
  * SilverWare
  *  
- * Copyright (C) 2010 - 2013 the original author or authors.
+ * Copyright (C) 2010 - 2016 the original author or authors.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ package io.silverware.microservices.silver.services;
 import io.silverware.microservices.Context;
 import io.silverware.microservices.MicroserviceMetaData;
 import io.silverware.microservices.annotations.InvocationPolicy;
-import io.silverware.microservices.silver.services.lookup.RandomRobinLookupStrategy;
+import io.silverware.microservices.silver.services.lookup.RoundRobinLookupStrategy;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -44,9 +44,12 @@ public class LookupStrategyFactory {
    /**
     * Returns strategy based on given parameters
     *
-    * @param context  silverware context
-    * @param metaData - metadata for microservice
-    * @param options  - other options
+    * @param context
+    *       silverware context
+    * @param metaData
+    *       - metadata for microservice
+    * @param options
+    *       - other options
     * @return strategy
     */
    public static LookupStrategy getStrategy(final Context context, final MicroserviceMetaData metaData, final Set<Annotation> options) {
@@ -69,7 +72,7 @@ public class LookupStrategyFactory {
       }
 
       if (strategy == null) {
-         strategy = new RandomRobinLookupStrategy();
+         strategy = new RoundRobinLookupStrategy();
          strategy.initialize(context, metaData, options);
       }
 

--- a/microservices/src/main/java/io/silverware/microservices/silver/services/lookup/AbstractLookupStrategy.java
+++ b/microservices/src/main/java/io/silverware/microservices/silver/services/lookup/AbstractLookupStrategy.java
@@ -2,7 +2,7 @@
  * -----------------------------------------------------------------------\
  * SilverWare
  *  
- * Copyright (C) 2010 - 2013 the original author or authors.
+ * Copyright (C) 2010 - 2016 the original author or authors.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microservices/src/main/java/io/silverware/microservices/silver/services/lookup/FirstFoundLocalLookupStrategy.java
+++ b/microservices/src/main/java/io/silverware/microservices/silver/services/lookup/FirstFoundLocalLookupStrategy.java
@@ -2,7 +2,7 @@
  * -----------------------------------------------------------------------\
  * SilverWare
  *  
- * Copyright (C) 2010 - 2013 the original author or authors.
+ * Copyright (C) 2010 - 2016 the original author or authors.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,21 +19,23 @@
  */
 package io.silverware.microservices.silver.services.lookup;
 
-import java.util.Random;
+import java.util.Set;
 
 /**
  * Lookup just local service implementations.
  *
  * @author <a href="mailto:marvenec@gmail.com">Martin Večeřa</a>
  */
-public class LocalLookupStrategy extends AbstractLookupStrategy {
-
-   private Random rnd = new Random();
+public class FirstFoundLocalLookupStrategy extends AbstractLookupStrategy {
 
    @Override
    public Object getService() {
-      final Object[] services = context.lookupLocalMicroservice(metaData).toArray();
-      return services.length == 0 ? null : services[rnd.nextInt(services.length)];
+      Set<Object> services = context.lookupLocalMicroservice(metaData);
+      if (services.isEmpty()) {
+         throw new RuntimeException("No service found for: " + metaData);
+      }
+      return services.iterator().next();
+
    }
 
 }

--- a/microservices/src/main/java/io/silverware/microservices/silver/services/lookup/RandomRobinLookupStrategy.java
+++ b/microservices/src/main/java/io/silverware/microservices/silver/services/lookup/RandomRobinLookupStrategy.java
@@ -2,7 +2,7 @@
  * -----------------------------------------------------------------------\
  * SilverWare
  *  
- * Copyright (C) 2010 - 2013 the original author or authors.
+ * Copyright (C) 2010 - 2016 the original author or authors.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,18 +19,20 @@
  */
 package io.silverware.microservices.silver.services.lookup;
 
-import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * @author <a href="mailto:marvenec@gmail.com">Martin Večeřa</a>
  */
 public class RandomRobinLookupStrategy extends AbstractLookupStrategy {
 
-   private Random rnd = new Random();
-
    @Override
    public Object getService() {
-      final Object[] services = context.lookupMicroservice(metaData).toArray();
-      return services[rnd.nextInt(services.length)];
+      Set<Object> services = context.lookupMicroservice(metaData);
+      if (services.isEmpty()) {
+         throw new RuntimeException("No service found for: " + metaData);
+      }
+      return services.toArray()[ThreadLocalRandom.current().nextInt(services.size())];
    }
 }

--- a/microservices/src/test/java/io/silverware/microservices/silver/services/lookup/AbstractLookupStrategyTest.java
+++ b/microservices/src/test/java/io/silverware/microservices/silver/services/lookup/AbstractLookupStrategyTest.java
@@ -1,0 +1,63 @@
+/*
+ * -----------------------------------------------------------------------\
+ * SilverWare
+ *
+ * Copyright (C) 2010 - 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------/
+ */
+package io.silverware.microservices.silver.services.lookup;
+
+import static java.util.Collections.emptySet;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.silverware.microservices.Context;
+import io.silverware.microservices.MicroserviceMetaData;
+import io.silverware.microservices.silver.services.LookupStrategy;
+
+import org.testng.annotations.Test;
+
+import mockit.StrictExpectations;
+import mockit.Tested;
+
+/**
+ * @author Slavomír Krupa (slavomir.krupa@gmail.com)
+ */
+public abstract class AbstractLookupStrategyTest {
+
+   public static final String API = "api";
+   public static final String IMPL = "impl";
+   public static final MicroserviceMetaData META_DATA = new MicroserviceMetaData(AbstractLookupStrategyTest.class.getName(), AbstractLookupStrategyTest.class, emptySet(), emptySet(), API, IMPL);
+
+   protected Context context = new Context();
+
+   @Tested
+   protected LookupStrategy strategy;
+
+   @Test
+   public void testGetServiceWithoutResult() throws Exception {
+      new StrictExpectations(Context.class) {{
+         context.lookupMicroservice(META_DATA);
+         minTimes = 0;
+         maxTimes = 1;
+         result = emptySet();
+         context.lookupLocalMicroservice(META_DATA);
+         minTimes = 0;
+         maxTimes = 1;
+         result = emptySet();
+      }};
+      assertThatThrownBy(() -> strategy.getService()).isInstanceOf(RuntimeException.class).hasMessageContaining(META_DATA.toString());
+   }
+
+}

--- a/microservices/src/test/java/io/silverware/microservices/silver/services/lookup/FirstFoundLocalLookupStrategyTest.java
+++ b/microservices/src/test/java/io/silverware/microservices/silver/services/lookup/FirstFoundLocalLookupStrategyTest.java
@@ -1,0 +1,64 @@
+/*
+ * -----------------------------------------------------------------------\
+ * SilverWare
+ *
+ * Copyright (C) 2010 - 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------/
+ */
+package io.silverware.microservices.silver.services.lookup;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptySet;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.silverware.microservices.Context;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import mockit.Expectations;
+
+/**
+ * @author Slavomír Krupa (slavomir.krupa@gmail.com)
+ */
+public class FirstFoundLocalLookupStrategyTest extends AbstractLookupStrategyTest {
+   @BeforeMethod
+   public void initStrategy() {
+      strategy = new FirstFoundLocalLookupStrategy();
+      strategy.initialize(context, META_DATA, emptySet());
+   }
+
+   @Test
+   public void testGetService() throws Exception {
+      Set<Object> expectedResult = new HashSet<>(asList("1", "2", "3"));
+      new Expectations(Context.class) {{
+         context.lookupLocalMicroservice(META_DATA);
+         times = 4;
+         result = expectedResult;
+      }};
+
+      List<Object> result = new ArrayList<>();
+      for (int i = 0; i < 4; i++) {
+         result.add(strategy.getService());
+      }
+      assertThat(result).containsExactly("1", "1", "1", "1");
+
+   }
+}

--- a/microservices/src/test/java/io/silverware/microservices/silver/services/lookup/RandomRobinLookupStrategyTest.java
+++ b/microservices/src/test/java/io/silverware/microservices/silver/services/lookup/RandomRobinLookupStrategyTest.java
@@ -1,0 +1,71 @@
+/*
+ * -----------------------------------------------------------------------\
+ * SilverWare
+ *
+ * Copyright (C) 2010 - 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------/
+ */
+package io.silverware.microservices.silver.services.lookup;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptySet;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.silverware.microservices.Context;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+
+import mockit.Expectations;
+
+/**
+ * @author Slavomír Krupa (slavomir.krupa@gmail.com)
+ */
+public class RandomRobinLookupStrategyTest extends AbstractLookupStrategyTest {
+
+   @BeforeMethod
+   public void initStrategy() {
+      strategy = new RandomRobinLookupStrategy();
+      strategy.initialize(context, META_DATA, emptySet());
+   }
+
+   @Test
+   public void testGetService() throws Exception {
+      Set<Object> expectedResult = new HashSet<>(asList("1", "2", "3"));
+      ThreadLocalRandom rnd = ThreadLocalRandom.current();
+      new Expectations(Context.class, ThreadLocalRandom.class) {{
+         context.lookupMicroservice(META_DATA);
+         times = 4;
+         result = expectedResult;
+         rnd.nextInt(anyInt);
+         times = 4;
+         result = 1;
+      }};
+
+      List<Object> result = new ArrayList<>();
+      for (int i = 0; i < 4; i++) {
+         result.add(strategy.getService());
+      }
+      assertThat(result).containsExactly("2", "2", "2", "2");
+
+   }
+
+}

--- a/microservices/src/test/java/io/silverware/microservices/silver/services/lookup/RoundRobinLookupStrategyTest.java
+++ b/microservices/src/test/java/io/silverware/microservices/silver/services/lookup/RoundRobinLookupStrategyTest.java
@@ -1,0 +1,66 @@
+/*
+ * -----------------------------------------------------------------------\
+ * SilverWare
+ *
+ * Copyright (C) 2010 - 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------/
+ */
+package io.silverware.microservices.silver.services.lookup;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptySet;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.silverware.microservices.Context;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import mockit.Expectations;
+
+/**
+ * @author Slavomír Krupa (slavomir.krupa@gmail.com)
+ */
+public class RoundRobinLookupStrategyTest extends AbstractLookupStrategyTest {
+
+   @BeforeMethod
+   public void initStrategy() {
+      strategy = new RoundRobinLookupStrategy();
+      strategy.initialize(context, META_DATA, emptySet());
+   }
+
+   @Test
+   public void testGetService() throws Exception {
+      Set<Object> expectedResult = new HashSet<>(asList("1", "2"));
+      new Expectations(Context.class) {{
+         context.lookupMicroservice(META_DATA);
+         times = 4;
+         result = expectedResult;
+      }};
+
+      List<Object> result = new ArrayList<>();
+      for (int i = 0; i < 4; i++) {
+         result.add(strategy.getService());
+      }
+      assertThat(result).containsExactly("1", "2", "1", "2");
+
+   }
+
+}


### PR DESCRIPTION
* When no service was found exception message had no added information.
"IllegalArgumentException:bound must be positive"
or propagated NullPointer exception.
Now runtime exception explicitly mentions metadata without
microservice implementation.


* New implemenation of lookup factory based on Round-robin scheduling is
implemented.

* Default lookup strategy is changed to Round-robin.