### PR TITLE
Use unique proxy for each injection point

### DIFF
--- a/cdi-microservice-provider/src/main/java/io/silverware/microservices/annotations/MicroserviceProxy.java
+++ b/cdi-microservice-provider/src/main/java/io/silverware/microservices/annotations/MicroserviceProxy.java
@@ -2,7 +2,7 @@
  * -----------------------------------------------------------------------\
  * SilverWare
  *  
- * Copyright (C) 2010 - 2016 the original author or authors.
+ * Copyright (C) 2016 the original author or authors.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,9 @@
 package io.silverware.microservices.annotations;
 
 import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
@@ -28,23 +31,26 @@ import java.lang.annotation.Target;
 import javax.inject.Qualifier;
 
 /**
- * Microservice reference.
- *
- * Use this annotation, in conjunction with the {@link javax.inject.Inject}
- * annotation, to inject a reference to a Microservice.
- *
- * @author <a href="mailto:marvenec@gmail.com">Martin Večeřa</a>
+ * Specifies which {@link io.silverware.microservices.providers.cdi.internal.MicroserviceProxyBean} is used for the given injection point.
  */
 @Qualifier
-@Target({ FIELD })
+@Target({ TYPE, FIELD, PARAMETER, METHOD })
 @Retention(RUNTIME)
 @Documented
-public @interface MicroserviceReference {
+public @interface MicroserviceProxy {
 
    /**
-    * Get the name of the Microservice that should be injected.
+    * The name of the microservice bean which is the proxy being injected into.
     *
-    * @return The name of the Microservice to be injected.
+    * @return microservice bean name
     */
-   String value() default "";
+   String beanName();
+
+   /**
+    * The field of the microservice bean which is the proxy being injected into.
+    *
+    * @return injected field name
+    */
+   String fieldName();
+
 }

--- a/cdi-microservice-provider/src/main/java/io/silverware/microservices/providers/cdi/internal/DefaultMethodHandler.java
+++ b/cdi-microservice-provider/src/main/java/io/silverware/microservices/providers/cdi/internal/DefaultMethodHandler.java
@@ -19,7 +19,10 @@
  */
 package io.silverware.microservices.providers.cdi.internal;
 
+import static io.silverware.microservices.providers.cdi.util.AnnotationUtil.matches;
+
 import io.silverware.microservices.MicroserviceMetaData;
+import io.silverware.microservices.annotations.MicroserviceProxy;
 import io.silverware.microservices.annotations.MicroserviceReference;
 import io.silverware.microservices.providers.cdi.util.VersionResolver;
 import io.silverware.microservices.silver.services.LookupStrategy;
@@ -49,7 +52,10 @@ public class DefaultMethodHandler extends MicroserviceMethodHandler {
    protected DefaultMethodHandler(final MicroserviceProxyBean proxyBean) throws Exception {
       this.proxyBean = proxyBean;
 
-      final Set<Annotation> qualifiers = proxyBean.getQualifiers().stream().filter(qualifier -> !qualifier.annotationType().getName().equals(MicroserviceReference.class.getName())).collect(Collectors.toSet());
+      final Set<Annotation> qualifiers = proxyBean.getQualifiers().stream()
+                                                  .filter(qualifier -> !matches(qualifier, MicroserviceReference.class))
+                                                  .filter(qualifier -> !matches(qualifier, MicroserviceProxy.class))
+                                                  .collect(Collectors.toSet());
       final MicroserviceMetaData metaData = VersionResolver.createMicroserviceMetadata(proxyBean.getMicroserviceName(), proxyBean.getServiceInterface(), qualifiers, proxyBean.getAnnotations());
 
       this.lookupStrategy = LookupStrategyFactory.getStrategy(proxyBean.getContext(), metaData, proxyBean.getAnnotations());

--- a/cdi-microservice-provider/src/main/java/io/silverware/microservices/providers/cdi/internal/MicroserviceInjectionPoint.java
+++ b/cdi-microservice-provider/src/main/java/io/silverware/microservices/providers/cdi/internal/MicroserviceInjectionPoint.java
@@ -1,0 +1,84 @@
+/*
+ * -----------------------------------------------------------------------\
+ * SilverWare
+ *  
+ * Copyright (C) 2016 the original author or authors.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------/
+ */
+package io.silverware.microservices.providers.cdi.internal;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Member;
+import java.lang.reflect.Type;
+import java.util.HashSet;
+import java.util.Set;
+import javax.enterprise.inject.spi.Annotated;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.InjectionPoint;
+
+/**
+ * Injection point wrapper that makes qualifiers modifiable.
+ */
+public class MicroserviceInjectionPoint implements InjectionPoint {
+
+   private final InjectionPoint injectionPoint;
+   private final Set<Annotation> qualifiers;
+
+   /**
+    * Wraps given injection point and puts its qualifiers to modifiable collection.
+    *
+    * @param injectionPoint
+    *       wrapped injection point
+    */
+   public MicroserviceInjectionPoint(final InjectionPoint injectionPoint) {
+      this.injectionPoint = injectionPoint;
+      this.qualifiers = new HashSet<>(injectionPoint.getQualifiers());
+   }
+
+   @Override
+   public Type getType() {
+      return injectionPoint.getType();
+   }
+
+   @Override
+   public Set<Annotation> getQualifiers() {
+      return qualifiers;
+   }
+
+   @Override
+   public Bean<?> getBean() {
+      return injectionPoint.getBean();
+   }
+
+   @Override
+   public Member getMember() {
+      return injectionPoint.getMember();
+   }
+
+   @Override
+   public Annotated getAnnotated() {
+      return injectionPoint.getAnnotated();
+   }
+
+   @Override
+   public boolean isDelegate() {
+      return injectionPoint.isDelegate();
+   }
+
+   @Override
+   public boolean isTransient() {
+      return injectionPoint.isTransient();
+   }
+}

--- a/cdi-microservice-provider/src/main/java/io/silverware/microservices/providers/cdi/internal/MicroserviceProxyAnnotationLiteral.java
+++ b/cdi-microservice-provider/src/main/java/io/silverware/microservices/providers/cdi/internal/MicroserviceProxyAnnotationLiteral.java
@@ -1,0 +1,49 @@
+/*
+ * -----------------------------------------------------------------------\
+ * SilverWare
+ *  
+ * Copyright (C) 2016 the original author or authors.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------/
+ */
+package io.silverware.microservices.providers.cdi.internal;
+
+import io.silverware.microservices.annotations.MicroserviceProxy;
+
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.enterprise.util.AnnotationLiteral;
+
+/**
+ * Implementation of {@link io.silverware.microservices.annotations.MicroserviceProxy} for given {@link javax.enterprise.inject.spi.InjectionPoint}.
+ */
+public class MicroserviceProxyAnnotationLiteral extends AnnotationLiteral<MicroserviceProxy> implements MicroserviceProxy {
+
+   private final String beanName;
+   private final String fieldName;
+
+   public MicroserviceProxyAnnotationLiteral(final InjectionPoint injectionPoint) {
+      this.beanName = injectionPoint.getBean().getName();
+      this.fieldName = injectionPoint.getMember().getName();
+   }
+
+   @Override
+   public String beanName() {
+      return beanName;
+   }
+
+   @Override
+   public String fieldName() {
+      return fieldName;
+   }
+}

--- a/cdi-microservice-provider/src/main/java/io/silverware/microservices/providers/cdi/util/AnnotationUtil.java
+++ b/cdi-microservice-provider/src/main/java/io/silverware/microservices/providers/cdi/util/AnnotationUtil.java
@@ -1,0 +1,46 @@
+/*
+ * -----------------------------------------------------------------------\
+ * SilverWare
+ *  
+ * Copyright (C) 2016 the original author or authors.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------/
+ */
+package io.silverware.microservices.providers.cdi.util;
+
+import java.lang.annotation.Annotation;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Helps to work with annotation types.
+ */
+public class AnnotationUtil {
+
+   private AnnotationUtil() {
+   }
+
+   public static boolean matches(final Annotation annotation, final Class<? extends Annotation> annotationType) {
+      return annotation.annotationType().isAssignableFrom(annotationType);
+   }
+
+   public static boolean containsAnnotation(final Set<Annotation> annotations, final Class<? extends Annotation> annotationType) {
+      return annotations.stream().anyMatch(annotation -> matches(annotation, annotationType));
+   }
+
+   public static <T extends Annotation> Optional<T> findAnnotation(final Set<Annotation> annotations, final Class<T> annotationType) {
+      return annotations.stream().filter(annotation -> matches(annotation, annotationType)).findFirst().map(annotationType::cast);
+   }
+
+}


### PR DESCRIPTION
These changes the way proxies are created. There was only a single proxy for given microservice before but now a new proxy is created for every injection point.

This is needed for Hystrix integration as well as for versioning.