### PR TITLE
Add Hystrix thread pool size configuration

### DIFF
--- a/hystrix-microservice-provider/pom.xml
+++ b/hystrix-microservice-provider/pom.xml
@@ -10,6 +10,8 @@
    <modelVersion>4.0.0</modelVersion>
 
    <artifactId>hystrix-microservice-provider</artifactId>
+   <packaging>jar</packaging>
+   <name>Hystrix Microservices Provider</name>
 
    <dependencies>
       <!-- internal -->

--- a/hystrix-microservice-provider/src/main/java/io/silverware/microservices/annotations/hystrix/basic/ThreadPool.java
+++ b/hystrix-microservice-provider/src/main/java/io/silverware/microservices/annotations/hystrix/basic/ThreadPool.java
@@ -35,11 +35,20 @@ import java.lang.annotation.Target;
 @Target({ ElementType.FIELD, ElementType.METHOD, ElementType.TYPE })
 public @interface ThreadPool {
 
+   int DEFAULT_SIZE = 10;
+
    /**
     * Defines the name of the thread pool used to execute Hystrix commands.
     *
     * @return the name of the thread pool
     */
-   String value();
+   String name() default "";
+
+   /**
+    * Defines the size of the thread pool used to execute Hystrix commands.
+    *
+    * @return number of threads in the thread pool
+    */
+   int size() default DEFAULT_SIZE;
 
 }

--- a/hystrix-microservice-provider/src/main/java/io/silverware/microservices/providers/hystrix/configuration/AnnotationScanner.java
+++ b/hystrix-microservice-provider/src/main/java/io/silverware/microservices/providers/hystrix/configuration/AnnotationScanner.java
@@ -132,7 +132,9 @@ public class AnnotationScanner {
          if (annotation.annotationType() == ThreadPool.class) {
             ThreadPool threadPool = (ThreadPool) annotation;
             builder.hystrixActive(true)
-                   .threadPoolKey(threadPool.value());
+                   .threadPoolKey(threadPool.name())
+                   .threadPoolProperty(ThreadPoolProperties.CORE_SIZE, String.valueOf(threadPool.size()))
+                   .threadPoolProperty(ThreadPoolProperties.MAXIMUM_SIZE, String.valueOf(threadPool.size()));
          }
 
          if (annotation.annotationType() == Timeout.class) {

--- a/hystrix-microservice-provider/src/main/java/io/silverware/microservices/providers/hystrix/configuration/SetterFactory.java
+++ b/hystrix-microservice-provider/src/main/java/io/silverware/microservices/providers/hystrix/configuration/SetterFactory.java
@@ -206,6 +206,11 @@ public class SetterFactory {
          setter.withCoreSize(Integer.parseInt(coreSize));
       }
 
+      String maximumSize = threadPoolProperties.get(ThreadPoolProperties.MAXIMUM_SIZE);
+      if (maximumSize != null) {
+         setter.withMaximumSize(Integer.parseInt(maximumSize));
+      }
+
       String keepAliveTimeMinutes = threadPoolProperties.get(ThreadPoolProperties.KEEP_ALIVE_TIME_MINUTES);
       if (keepAliveTimeMinutes != null) {
          setter.withKeepAliveTimeMinutes(Integer.parseInt(keepAliveTimeMinutes));

--- a/hystrix-microservice-provider/src/main/java/io/silverware/microservices/providers/hystrix/configuration/ThreadPoolProperties.java
+++ b/hystrix-microservice-provider/src/main/java/io/silverware/microservices/providers/hystrix/configuration/ThreadPoolProperties.java
@@ -27,6 +27,7 @@ package io.silverware.microservices.providers.hystrix.configuration;
 public interface ThreadPoolProperties {
 
    String CORE_SIZE = "coreSize";
+   String MAXIMUM_SIZE = "maximumSize";
    String KEEP_ALIVE_TIME_MINUTES = "keepAliveTimeMinutes";
    String MAX_QUEUE_SIZE = "maxQueueSize";
    String METRICS_ROLLING_STATS_NUM_BUCKETS = "metrics.rollingStats.numBuckets";

--- a/hystrix-microservice-provider/src/test/java/io/silverware/microservices/providers/hystrix/configuration/AnnotationScannerHighLevelFieldTest.java
+++ b/hystrix-microservice-provider/src/test/java/io/silverware/microservices/providers/hystrix/configuration/AnnotationScannerHighLevelFieldTest.java
@@ -19,13 +19,14 @@
  */
 package io.silverware.microservices.providers.hystrix.configuration;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.silverware.microservices.annotations.hystrix.basic.Cached;
 import io.silverware.microservices.annotations.hystrix.basic.CircuitBreaker;
 import io.silverware.microservices.annotations.hystrix.basic.Fail;
 import io.silverware.microservices.annotations.hystrix.basic.ThreadPool;
 import io.silverware.microservices.annotations.hystrix.basic.Timeout;
 
-import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
 import org.testng.annotations.Test;
 
@@ -37,6 +38,7 @@ public class AnnotationScannerHighLevelFieldTest extends AnnotationScannerTestBa
    private static final int CIRCUIT_BREAKER_REQUEST_VOLUME = 100;
    private static final int CIRCUIT_BREAKER_SLEEP_WINDOW = 1000;
    private static final String THREAD_POOL_NAME = "TestingThreadPool";
+   private static final int THREAD_POOL_SIZE = 100;
    private static final int TIMEOUT_VALUE = 2000;
 
    private Object noAnnotations;
@@ -133,7 +135,7 @@ public class AnnotationScannerHighLevelFieldTest extends AnnotationScannerTestBa
    public void testIgnoredException() {
       MethodConfig methodConfig = scanToMethodConfig("ignoredException");
 
-      Assertions.assertThat(methodConfig.getIgnoredExceptions()).containsOnly(IllegalArgumentException.class);
+      assertThat(methodConfig.getIgnoredExceptions()).containsOnly(IllegalArgumentException.class);
    }
 
    @Fail({ NullPointerException.class, IllegalArgumentException.class, IllegalStateException.class })
@@ -143,17 +145,31 @@ public class AnnotationScannerHighLevelFieldTest extends AnnotationScannerTestBa
    public void testIgnoredExceptions() {
       MethodConfig methodConfig = scanToMethodConfig("ignoredExceptions");
 
-      Assertions.assertThat(methodConfig.getIgnoredExceptions()).containsOnly(NullPointerException.class, IllegalArgumentException.class, IllegalStateException.class);
+      assertThat(methodConfig.getIgnoredExceptions()).containsOnly(NullPointerException.class, IllegalArgumentException.class, IllegalStateException.class);
    }
 
-   @ThreadPool(THREAD_POOL_NAME)
-   private Object threadPool;
+   @ThreadPool(name = THREAD_POOL_NAME)
+   private Object threadPoolName;
 
    @Test
-   public void testThreadPool() {
-      MethodConfig methodConfig = scanToMethodConfig("threadPool");
+   public void testThreadPoolName() {
+      MethodConfig methodConfig = scanToMethodConfig("threadPoolName");
 
-      Assertions.assertThat(methodConfig.getThreadPoolKey()).isEqualTo(THREAD_POOL_NAME);
+      assertThat(methodConfig.getThreadPoolKey()).isEqualTo(THREAD_POOL_NAME);
+      assertThat(methodConfig.getThreadPoolProperties()).containsEntry(ThreadPoolProperties.CORE_SIZE, String.valueOf(ThreadPool.DEFAULT_SIZE));
+      assertThat(methodConfig.getThreadPoolProperties()).containsEntry(ThreadPoolProperties.MAXIMUM_SIZE, String.valueOf(ThreadPool.DEFAULT_SIZE));
+   }
+
+   @ThreadPool(size = THREAD_POOL_SIZE)
+   private Object threadPoolSize;
+
+   @Test
+   public void testThreadPoolSize() {
+      MethodConfig methodConfig = scanToMethodConfig("threadPoolSize");
+
+      assertThat(methodConfig.getThreadPoolKey()).isEmpty();
+      assertThat(methodConfig.getThreadPoolProperties()).containsEntry(ThreadPoolProperties.CORE_SIZE, String.valueOf(THREAD_POOL_SIZE));
+      assertThat(methodConfig.getThreadPoolProperties()).containsEntry(ThreadPoolProperties.MAXIMUM_SIZE, String.valueOf(THREAD_POOL_SIZE));
    }
 
    @Timeout

--- a/hystrix-microservice-provider/src/test/java/io/silverware/microservices/providers/hystrix/configuration/AnnotationScannerHighLevelInterfaceTest.java
+++ b/hystrix-microservice-provider/src/test/java/io/silverware/microservices/providers/hystrix/configuration/AnnotationScannerHighLevelInterfaceTest.java
@@ -147,7 +147,7 @@ public class AnnotationScannerHighLevelInterfaceTest extends AnnotationScannerTe
       @Fail(NullPointerException.class)
       String method2();
 
-      @ThreadPool(THREAD_POOL_NAME)
+      @ThreadPool(name = THREAD_POOL_NAME)
       @Timeout
       int method3(long param);
 
@@ -163,7 +163,7 @@ public class AnnotationScannerHighLevelInterfaceTest extends AnnotationScannerTe
       @Fail(NullPointerException.class)
       String method2();
 
-      @ThreadPool(THREAD_POOL_NAME)
+      @ThreadPool(name = THREAD_POOL_NAME)
       @Timeout(TIMEOUT_VALUE)
       int method3(long param);
 


### PR DESCRIPTION
Thread pool size can be set by high-level `@ThreadPool` annotation and maximum size of thread pool can be set by low-level annotations (new in Hystrix 1.5.7).