### PR TITLE
Bind rest server to all interfaces instead of localhost by default

### DIFF
--- a/http-server-microservice-provider/src/main/java/io/silverware/microservices/providers/http/HttpServerMicroserviceProvider.java
+++ b/http-server-microservice-provider/src/main/java/io/silverware/microservices/providers/http/HttpServerMicroserviceProvider.java
@@ -67,7 +67,7 @@ public class HttpServerMicroserviceProvider implements MicroserviceProvider, Htt
    public void initialize(final Context context) {
       this.context = context;
       context.getProperties().putIfAbsent(HTTP_SERVER_PORT, 8080);
-      context.getProperties().putIfAbsent(HTTP_SERVER_ADDRESS, "localhost");
+      context.getProperties().putIfAbsent(HTTP_SERVER_ADDRESS, "0.0.0.0");
       context.getProperties().putIfAbsent(HTTP_SERVER_REST_CONTEXT_PATH, "/silverware");
       context.getProperties().putIfAbsent(HTTP_SERVER_REST_SERVLET_MAPPING_PREFIX, "rest");
 
@@ -131,7 +131,11 @@ public class HttpServerMicroserviceProvider implements MicroserviceProvider, Htt
             }
             this.server.start(builder);
             this.server.deploy(deploymentInfo());
-            log.info("Started Http Server.");
+            log.info("Started http server at {}:{}/{}{} ",
+                  readProperty(HTTP_SERVER_ADDRESS),
+                  readProperty(HTTP_SERVER_PORT),
+                  readProperty(HTTP_SERVER_REST_SERVLET_MAPPING_PREFIX),
+                  readProperty(HTTP_SERVER_REST_CONTEXT_PATH));
             this.deployed = true;
 
             while (!Thread.currentThread().isInterrupted()) {
@@ -141,7 +145,6 @@ public class HttpServerMicroserviceProvider implements MicroserviceProvider, Htt
             Utils.shutdownLog(log, ie);
          } catch (final Exception ie) {
             log.error("Error while initializing.", ie);
-            ;
          } finally {
             this.server.stop();
             this.deployed = false;
@@ -157,15 +160,15 @@ public class HttpServerMicroserviceProvider implements MicroserviceProvider, Htt
       resteasyDeployment.setResourceFactories(resourceFactories());
       final DeploymentInfo deploymentInfo = this.server.undertowDeployment(resteasyDeployment,
             String.valueOf(this.context.getProperties().get(HTTP_SERVER_REST_SERVLET_MAPPING_PREFIX)))
-            .setContextPath(String.valueOf(this.context.getProperties().get(HTTP_SERVER_REST_CONTEXT_PATH)))
-            .setClassLoader(this.getClass().getClassLoader())
-            .setDeploymentName("Silverware rest deployment");
+                                                       .setContextPath(String.valueOf(this.context.getProperties().get(HTTP_SERVER_REST_CONTEXT_PATH)))
+                                                       .setClassLoader(this.getClass().getClassLoader())
+                                                       .setDeploymentName("Silverware rest deployment");
       if (this.sslEnabled) {
          deploymentInfo
                .addSecurityConstraint(new SecurityConstraint().addWebResourceCollection(new WebResourceCollection()
                      .addUrlPattern("/*"))
-                     .setTransportGuaranteeType(TransportGuaranteeType.CONFIDENTIAL)
-                     .setEmptyRoleSemantic(SecurityInfo.EmptyRoleSemantic.PERMIT))
+                                                              .setTransportGuaranteeType(TransportGuaranteeType.CONFIDENTIAL)
+                                                              .setEmptyRoleSemantic(SecurityInfo.EmptyRoleSemantic.PERMIT))
                .setConfidentialPortManager(exchange -> sslPort());
       }
       return deploymentInfo;

--- a/http-server-microservice-provider/src/test/java/io/silverware/microservices/providers/http/SSLTest.java
+++ b/http-server-microservice-provider/src/test/java/io/silverware/microservices/providers/http/SSLTest.java
@@ -72,6 +72,7 @@ public class SSLTest {
    public void defaultSslConfigurationTest() throws Exception {
       final BootUtil bootUtil = new BootUtil();
       final Map<String, Object> platformProperties = bootUtil.getContext().getProperties();
+      platformProperties.put(HttpServerSilverService.HTTP_SERVER_ADDRESS, "localhost");
       platformProperties.put(HttpServerSilverService.HTTP_SERVER_PORT, 8282);
       platformProperties.put(HttpServerSilverService.HTTP_SERVER_SSL_ENABLED, "true");
 
@@ -90,7 +91,7 @@ public class SSLTest {
    public void sslConfigurationAbsolutePathTest() throws Exception {
       final BootUtil bootUtil = new BootUtil();
       final Map<String, Object> platformProperties = bootUtil.getContext().getProperties();
-
+      platformProperties.put(HttpServerSilverService.HTTP_SERVER_ADDRESS, "localhost");
       platformProperties.put(HttpServerSilverService.HTTP_SERVER_PORT, 8282);
       platformProperties.put(HttpServerSilverService.HTTP_SERVER_SSL_ENABLED, "true");
       platformProperties.put(
@@ -121,6 +122,7 @@ public class SSLTest {
    public void sslConfigurationResourcePathTest() throws Exception {
       final BootUtil bootUtil = new BootUtil();
       final Map<String, Object> platformProperties = bootUtil.getContext().getProperties();
+      platformProperties.put(HttpServerSilverService.HTTP_SERVER_ADDRESS, "localhost");
       platformProperties.put(HttpServerSilverService.HTTP_SERVER_PORT, 8282);
       platformProperties.put(HttpServerSilverService.HTTP_SERVER_SSL_ENABLED, "true");
       platformProperties


### PR DESCRIPTION
* this allows running in docker images and exposing the rest endpoint
* supports openshift and other cloud providers

**Note:** test with secured endpoint have pregenerated certificates
for localhost hence the change to "localhost"