### PR TITLE
Load configuration from property file and performance fixes

### DIFF
--- a/http-server-microservice-provider/src/main/java/io/silverware/microservices/providers/http/HttpServerMicroserviceProvider.java
+++ b/http-server-microservice-provider/src/main/java/io/silverware/microservices/providers/http/HttpServerMicroserviceProvider.java
@@ -121,7 +121,7 @@ public class HttpServerMicroserviceProvider implements MicroserviceProvider, Htt
          log.info("Hello from Http Server microservice provider!");
          try {
             final Builder builder = Undertow.builder().addHttpListener(
-                  (int) this.context.getProperties().get(HTTP_SERVER_PORT),
+                  Integer.valueOf(this.context.getProperties().get(HTTP_SERVER_PORT).toString()),
                   String.valueOf(this.context.getProperties().get(HTTP_SERVER_ADDRESS)));
             if (this.sslEnabled) {
                builder.addHttpsListener(

--- a/http-server-microservice-provider/src/main/java/io/silverware/microservices/providers/http/resteasy/SilverwareResourceFactory.java
+++ b/http-server-microservice-provider/src/main/java/io/silverware/microservices/providers/http/resteasy/SilverwareResourceFactory.java
@@ -19,13 +19,15 @@
  */
 package io.silverware.microservices.providers.http.resteasy;
 
+import io.silverware.microservices.Context;
+import io.silverware.microservices.MicroserviceMetaData;
+
 import org.jboss.resteasy.spi.HttpRequest;
 import org.jboss.resteasy.spi.HttpResponse;
 import org.jboss.resteasy.spi.ResourceFactory;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 
-import io.silverware.microservices.Context;
-import io.silverware.microservices.MicroserviceMetaData;
+import java.util.Set;
 
 /**
  * Silverware resource factory producing a Microservice from a context
@@ -36,6 +38,7 @@ import io.silverware.microservices.MicroserviceMetaData;
 public class SilverwareResourceFactory implements ResourceFactory {
    private final Context context;
    private final MicroserviceMetaData microserviceMetadata;
+   private volatile Object reference;
 
    /**
     * Ctor.
@@ -58,29 +61,28 @@ public class SilverwareResourceFactory implements ResourceFactory {
 
    @Override
    public void registered(final ResteasyProviderFactory factory) {
-      // TODO Auto-generated method stub
-
    }
 
    @Override
    public Object createResource(final HttpRequest request, final HttpResponse response,
          final ResteasyProviderFactory factory) {
-      /*
-       * What should follow if an empty set of microservices is returned?
-       */
-      return this.context.lookupMicroservice(this.microserviceMetadata).iterator().next();
+      if (reference == null) {
+         final Set<Object> proxies = this.context.lookupLocalMicroservice(this.microserviceMetadata);
+         if (proxies.isEmpty()) {
+            throw new RuntimeException("No REST service found for " + request + " and metadata " + microserviceMetadata);
+         }
+         reference = proxies.iterator().next();
+      }
+
+      return reference;
    }
 
    @Override
    public void requestFinished(final HttpRequest request, final HttpResponse response, final Object resource) {
-      // TODO Auto-generated method stub
-
    }
 
    @Override
    public void unregistered() {
-      // TODO Auto-generated method stub
-
    }
 
 }

--- a/microservices/src/main/java/io/silverware/microservices/Boot.java
+++ b/microservices/src/main/java/io/silverware/microservices/Boot.java
@@ -19,6 +19,10 @@
  */
 package io.silverware.microservices;
 
+import static io.silverware.microservices.Executor.SHUTDOWN_HOOK;
+
+import io.silverware.microservices.util.Utils;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -35,8 +39,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Properties;
-
-import io.silverware.microservices.util.Utils;
 
 /**
  * Main class to boot the Microservices platforms.
@@ -56,21 +58,26 @@ public final class Boot {
     *
     * Uses Executor Microservice Provider as a boot hook.
     *
-    * @param args Any additional properties can be specified at the command line via -Dprop=value.
+    * @param args
+    *       Any additional properties can be specified at the command line via -Dprop=value.
     */
    public static void main(final String... args) {
       preMainConfig();
 
       log.info("=== Welcome to SilverWare ===");
-
+      final Context initialContext = getInitialContext(args);
       try {
-         Executor.bootHook(getInitialContext(args));
+         Executor.bootHook(initialContext);
       } catch (InterruptedException ie) {
          Utils.shutdownLog(log, ie);
       }
 
       log.info("Goodbye.");
       logFlush(); // this is needed for Ctrl+C termination
+      // if we had clean up everything. Why should we end with non-zero code?
+      if (Boolean.parseBoolean(String.valueOf(initialContext.getProperties().get(SHUTDOWN_HOOK)))) {
+         System.exit(0);
+      }
    }
 
    /**
@@ -89,27 +96,18 @@ public final class Boot {
    }
 
    /**
-    * Load custom properties from file on a classpath.
-    *
-    * @return Properties from silverware.properties when present on a classpath.
+    * Load custom properties from filepath
+    * @param propertiesFile file with properties which will be loaded
+    * @return Properties from given file path
     */
-   private static Properties loadProperties() {
-      Properties props = new Properties();
-      try {
-         props.load(Boot.class.getResourceAsStream("silverware.properties"));
-      } catch (NullPointerException | IOException ioe) {
-         log.info("No configuration property file available. Using default values.");
-      }
-
-      return props;
-   }
 
    private static Properties loadProperties(final File propertiesFile) {
+      log.info("Loading configuration from file {}.", propertiesFile.getAbsolutePath());
       Properties props = new Properties();
       try (FileInputStream fis = new FileInputStream(propertiesFile)) {
          props.load(fis);
       } catch (IOException ioe) {
-         log.warn("Cannot read configuration property file %s.", propertiesFile.getAbsolutePath());
+         log.warn("Cannot read configuration property file {}.", propertiesFile.getAbsolutePath());
       }
 
       return props;
@@ -118,7 +116,8 @@ public final class Boot {
    /**
     * Creates initial context pre-filled with system properties, command line arguments, custom property file and default property file.
     *
-    * @param args Command line arguments.
+    * @param args
+    *       Command line arguments.
     * @return Initial context pre-filled with system properties, command line arguments, custom property file and default property file.
     */
    @SuppressWarnings("static-access")
@@ -141,10 +140,10 @@ public final class Boot {
          if (commandLine.hasOption(PROPERTY_FILE_LETTER)) {
             final File propertiesFile = new File(commandLine.getOptionValue(PROPERTY_FILE_LETTER));
             if (propertiesFile.exists()) {
-               final Properties props = loadProperties();
+               final Properties props = loadProperties(propertiesFile);
                props.forEach((key, val) -> contextProperties.putIfAbsent(key.toString(), val));
             } else {
-               log.error("Specified property file %s does not exists.", propertiesFile.getAbsolutePath());
+               log.error("Specified property file {} does not exists.", propertiesFile.getAbsolutePath());
             }
          }
       } catch (ParseException pe) {
@@ -152,12 +151,7 @@ public final class Boot {
          new HelpFormatter().printHelp("SilverWare usage:", options);
          System.exit(1);
       }
-
-      // now add in default properties from silverware.properties on a classpath
-      loadProperties().forEach((key, val) -> contextProperties.putIfAbsent(key.toString(), val));
-
-      context.getProperties().put(Executor.SHUTDOWN_HOOK, "true");
-
+      contextProperties.putIfAbsent(SHUTDOWN_HOOK, "true");
       return context;
    }
 }

--- a/microservices/src/main/java/io/silverware/microservices/Executor.java
+++ b/microservices/src/main/java/io/silverware/microservices/Executor.java
@@ -63,6 +63,7 @@ public class Executor implements MicroserviceProvider, ProvidingSilverService {
 
    /**
     * Property to omit a shutdown hook. Useful for tests mainly.
+    *  and especially BootTest#testFullBoot
     */
    public static final String SHUTDOWN_HOOK = "silverware.shutdown";
 
@@ -202,7 +203,7 @@ public class Executor implements MicroserviceProvider, ProvidingSilverService {
             shutdownThread.start();
 
             try {
-               shutdownThread.join();
+               shutdownThread.join(TimeUnit.SECONDS.toMillis(5));
             } catch (InterruptedException iee) {
                // we did our best
             }

--- a/microservices/src/test/java/io/silverware/microservices/BootTest.java
+++ b/microservices/src/test/java/io/silverware/microservices/BootTest.java
@@ -19,6 +19,8 @@
  */
 package io.silverware.microservices;
 
+import static io.silverware.microservices.Executor.SHUTDOWN_HOOK;
+
 import io.silverware.microservices.providers.MicroserviceProvider;
 import io.silverware.microservices.util.BootUtil;
 
@@ -61,7 +63,8 @@ public class BootTest {
 
    @Test
    public void testFullBoot() throws InterruptedException {
-      Boot.main();
+
+      Boot.main("-D" + SHUTDOWN_HOOK + "=false");
 
       Assert.assertTrue(semaphore.tryAcquire(50, TimeUnit.SECONDS), "Timed-out while waiting for platform startup.");
 


### PR DESCRIPTION
* the property file with configuration can be specified as -p FILE
* SilverWare now ends with zero code when everything is done
* Add timeout for shutdown thread
* Port can be stored as string in properties now
* Just single **local** lookup per rest service now occurs