### PR TITLE
Fix version resolution and remote invocation refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,14 @@ We achieve easy services monitoring through JMX by incorporating Jolokia.
 
 Enabling the following technologies in on our near-term roadmap. 
 
-* __CDI__ - _WORKS_ - Enables development of business code using simple java classes and injection. Integrates well with Camel.
+* [__CDI__](https://github.com/SilverThings/SilverWare/wiki/CDI-Microservice-Provider) - _WORKS_ - Enables development of business code using simple java classes and injection. Integrates well with Camel.
 * __Camel__ - _WORKS_ - Enables automatic startup of Camel routes and components in both Java classes and XML files. Also friends with CDI.
-* __REST__ - _PoC WORKS_ - It is possible to expose a CDI microservice via the REST interface. However, this is just a basic version, uses 
-  only JSON and no custom URL or parameters manipulation. Improvements are on the way!
+* [__REST__](https://github.com/SilverThings/SilverWare/wiki/http-server-microservice-provider) - _WORKS_ - It is possible to expose a CDI microservice via the REST interface.  
 * __Monitoring__ - _NOT TESTED_ - Theoreticaly completed, but not verified with an external monitoring console.
 * __ActiveMQ__ - _WORKS_ - Integration between CDI, Camel and ActiveMQ messaging. Microservices should be able to become an ultimate consumer and 
   producer of messges.
 * __Vert.x__ - _WORKS_ - Verticles should be deployed as standalone microservices as well.
-* __Clustering__ - _COMING SOON_ - It should be possible to call other microservice in a cluster transparently. There is a preliminary implementation for CDI but this
-  has never been tested. Also, it should be possible to share any messages of any of the integrated components in a cluster.
+* __Clustering__ - _WORKS_ - It is possible to call other microservice in a cluster transparently. 
 * __Languages__ - _PLANNED_ - Support of development of microservices in other JVM enabled languages.
 * __Transaction__ - _PLANNED_ - Integration with Narayana.
 * __Security__ - _PLANNED_ - Possible integration with Apiman.

--- a/cdi-microservice-provider/pom.xml
+++ b/cdi-microservice-provider/pom.xml
@@ -41,6 +41,16 @@
          <groupId>commons-beanutils</groupId>
          <artifactId>commons-beanutils</artifactId>
       </dependency>
+      <dependency>
+         <groupId>org.jmockit</groupId>
+         <artifactId>jmockit</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.assertj</groupId>
+         <artifactId>assertj-core</artifactId>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
    <build>
       <plugins>

--- a/cdi-microservice-provider/src/main/java/io/silverware/microservices/annotations/MicroserviceVersion.java
+++ b/cdi-microservice-provider/src/main/java/io/silverware/microservices/annotations/MicroserviceVersion.java
@@ -19,6 +19,8 @@
  */
 package io.silverware.microservices.annotations;
 
+import io.silverware.microservices.providers.cdi.util.VersionResolver;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
@@ -33,7 +35,7 @@ import java.lang.annotation.Target;
  * <li><strong>Injection point:</strong> can specify supported version of a Microservice API. </li>
  * </ul>
  * These versions are used in the lookup of the Microservices in the cluster.
- * See @{@link io.silverware.microservices.providers.cdi.util.VersionResolver}
+ * See @{@link VersionResolver}
  * See @{@link io.silverware.microservices.util.VersionComparator}
  *
  * @author Slavomír Krupa (slavomir.krupa@gmail.com)
@@ -41,7 +43,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Inherited
-@Target({ ElementType.TYPE })
+@Target({ ElementType.TYPE, ElementType.FIELD })
 public @interface MicroserviceVersion {
 
    /**
@@ -51,7 +53,7 @@ public @interface MicroserviceVersion {
 
    /**
     * Gets the implementation version of the Microservice.
-    * If not defined then {@link io.silverware.microservices.providers.cdi.util.VersionResolver} continues in search for microservice version.
+    * If not defined then {@link VersionResolver} continues in search for microservice version.
     */
    String implementation() default "";
 }

--- a/cdi-microservice-provider/src/main/java/io/silverware/microservices/providers/cdi/CdiMicroserviceProvider.java
+++ b/cdi-microservice-provider/src/main/java/io/silverware/microservices/providers/cdi/CdiMicroserviceProvider.java
@@ -23,7 +23,6 @@ import io.silverware.microservices.Context;
 import io.silverware.microservices.MicroserviceMetaData;
 import io.silverware.microservices.annotations.Microservice;
 import io.silverware.microservices.annotations.MicroserviceReference;
-import io.silverware.microservices.annotations.MicroserviceVersion;
 import io.silverware.microservices.providers.MicroserviceProvider;
 import io.silverware.microservices.providers.cdi.builtin.Configuration;
 import io.silverware.microservices.providers.cdi.builtin.CurrentContext;
@@ -33,7 +32,6 @@ import io.silverware.microservices.providers.cdi.internal.MicroservicesCDIExtens
 import io.silverware.microservices.providers.cdi.internal.MicroservicesInitEvent;
 import io.silverware.microservices.silver.CdiSilverService;
 import io.silverware.microservices.util.Utils;
-import io.silverware.microservices.util.VersionComparator;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -46,6 +44,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Priority;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.context.spi.CreationalContext;
@@ -59,8 +58,9 @@ import javax.interceptor.InvocationContext;
 
 /**
  * @author <a href="mailto:marvenec@gmail.com">Martin Večeřa</a>
- *         Changes in version resolution in lookupMicroservice
  * @author Slavomir Krupa (slavomir.krupa@gmail.com)
+ *         Changes in version resolution in lookupMicroservice
+ *         Added non static Weld
  */
 public class CdiMicroserviceProvider implements MicroserviceProvider, CdiSilverService {
 
@@ -75,6 +75,7 @@ public class CdiMicroserviceProvider implements MicroserviceProvider, CdiSilverS
     * Microservices context.
     */
    private Context context;
+   private BeanManager beanManager;
 
    @Override
    public void initialize(final Context context) {
@@ -95,16 +96,17 @@ public class CdiMicroserviceProvider implements MicroserviceProvider, CdiSilverS
    public void run() {
       try {
          log.info("Hello from CDI microservice provider!");
-
-         final Weld weld = new Weld();
+         final String weldName = String.valueOf(context.getProperties().get(Context.WELD_NAME));
+         final Weld weld = new Weld(weldName);
          final MicroservicesCDIExtension microservicesCDIExtension = new MicroservicesCDIExtension(this.context);
-         System.setProperty("org.jboss.weld.se.archive.isolation", "false");
+         weld.property("org.jboss.weld.se.archive.isolation", "false");
          weld.addExtension(microservicesCDIExtension);
 
          final WeldContainer container = weld.initialize();
          this.context.getProperties().put(BEAN_MANAGER, container.getBeanManager());
          this.context.getProperties().put(CDI_CONTAINER, container);
          this.context.getProperties().put(Storage.STORAGE, new HashMap<String, Object>());
+         this.beanManager = container.getBeanManager();
 
          log.info("Discovered the following microservice implementations:");
          this.context.getMicroservices().forEach(metaData -> log.info((" - " + metaData.toString())));
@@ -141,9 +143,8 @@ public class CdiMicroserviceProvider implements MicroserviceProvider, CdiSilverS
       final String name = microserviceMetaData.getName();
       final Class<?> type = microserviceMetaData.getType();
       final Set<Annotation> qualifiers = microserviceMetaData.getQualifiers();
-      final String apiVersion = microserviceMetaData.getApiVersion();
       final Set<Object> matchingBeansByName = new HashSet<>();
-      final Set<Object> matchingBeansByType = new HashSet<>();
+      final Set<Bean<?>> matchingBeansByType = new HashSet<>();
       boolean wasAlternative = false;
 
       /*
@@ -158,24 +159,15 @@ public class CdiMicroserviceProvider implements MicroserviceProvider, CdiSilverS
          In all cases, there must be precisely one result or an error is thrown.
        */
 
-      final BeanManager beanManager = ((BeanManager) this.context.getProperties().get(BEAN_MANAGER));
       final Set<Bean<?>> beans = beanManager.getBeans(type, qualifiers.toArray(new Annotation[qualifiers.size()]));
       for (final Bean<?> bean : beans) {
          if (bean.getBeanClass().isAnnotationPresent(Microservice.class) && !(bean instanceof MicroserviceProxyBean)) {
             final Bean<?> theBean = beanManager.resolve(Collections.singleton(bean));
-
-            if (theBean.getBeanClass().isAnnotationPresent(MicroserviceVersion.class)) {
-               final MicroserviceVersion versionAnnotation = theBean.getBeanClass().getAnnotation(MicroserviceVersion.class);
-               String implementationVersion = versionAnnotation.implementation();
-               if (!VersionComparator.forVersion(implementationVersion).satisfies(apiVersion)) {
-                  continue;
-               }
-            }
             final Microservice microserviceAnnotation = theBean.getBeanClass().getAnnotation(Microservice.class);
 
             if ((!microserviceAnnotation.value().isEmpty() && name.equals(microserviceAnnotation.value())) ||
                   (microserviceAnnotation.value().isEmpty() && name.equals(theBean.getName()))) {
-               matchingBeansByName.add(beanManager.getReference(theBean, type, beanManager.createCreationalContext(theBean)));
+               matchingBeansByName.add(beanManager.getReference(bean, type, beanManager.createCreationalContext(bean)));
             } else if (type.isAssignableFrom(theBean.getBeanClass())) {
                final Set<Annotation> qualifiersToCompare = new HashSet<>(theBean.getQualifiers());
                qualifiers.stream().forEach(qualifiersToCompare::remove);
@@ -185,15 +177,15 @@ public class CdiMicroserviceProvider implements MicroserviceProvider, CdiSilverS
                   if (bean.isAlternative()) {
                      if (!wasAlternative) {
                         matchingBeansByType.clear();
-                        matchingBeansByType.add(beanManager.getReference(theBean, type, beanManager.createCreationalContext(theBean)));
+                        matchingBeansByType.add(theBean);
                         wasAlternative = true;
                      } else {
-                        matchingBeansByType.add(beanManager.getReference(theBean, type, beanManager.createCreationalContext(theBean)));
+                        matchingBeansByType.add(theBean);
                         throw new IllegalStateException(String.format("There are more than alternate beans matching the query: %s. The beans are: %s.", microserviceMetaData.toString(), matchingBeansByType.toString()));
                      }
                   } else {
                      if (!wasAlternative) {
-                        matchingBeansByType.add(beanManager.getReference(theBean, type, beanManager.createCreationalContext(theBean)));
+                        matchingBeansByType.add(theBean);
                      } else {
                         // ignore this bean
                      }
@@ -203,16 +195,26 @@ public class CdiMicroserviceProvider implements MicroserviceProvider, CdiSilverS
          }
       }
 
-      if (matchingBeansByName.size() == 1) {
+      if (matchingBeansByName.size() == 1 &&
+            context.getSingleMetaDataForPredicate((m) -> m.getName().equals(name))
+                   .satisfiesJustVersion(microserviceMetaData)) {
          return matchingBeansByName;
       }
 
-      if (matchingBeansByName.size() > 1 || matchingBeansByType.size() > 1) {
-         throw new IllegalStateException(String.format("There are more than one beans matching the query: %s. The beans are: %s.", microserviceMetaData.toString(), matchingBeansByType.toString()));
+      // remove microservices with wrong version if they are specified in query
+      if (microserviceMetaData.getApiVersion() != null || microserviceMetaData.getImplVersion() != null) {
+         matchingBeansByType.removeIf(b ->
+               !context.getSingleMetaDataForPredicate((m) -> m.getType().equals(b.getBeanClass()))
+                       .satisfiesJustVersion(microserviceMetaData)
+         );
       }
+      if (matchingBeansByName.size() > 1 || matchingBeansByType.size() > 1) {
+         throw new IllegalStateException(String.format("There are more than one beans matching the query: %s. The beans are: type match: %s  name match:%s.", microserviceMetaData, matchingBeansByType, matchingBeansByName));
 
+      }
       // now we know that matchingBeansByType.size() <= 1
-      return matchingBeansByType;
+      return matchingBeansByType.stream().map(bean -> beanManager.getReference(bean, type, beanManager.createCreationalContext(bean))).collect(Collectors.toSet());
+
    }
 
    @Override

--- a/cdi-microservice-provider/src/main/java/io/silverware/microservices/providers/cdi/MicroserviceContext.java
+++ b/cdi-microservice-provider/src/main/java/io/silverware/microservices/providers/cdi/MicroserviceContext.java
@@ -19,14 +19,13 @@
  */
 package io.silverware.microservices.providers.cdi;
 
-import org.jboss.weld.bootstrap.api.helpers.RegistrySingletonProvider;
+import io.silverware.microservices.annotations.MicroserviceScoped;
+
 import org.jboss.weld.context.AbstractManagedContext;
 import org.jboss.weld.context.beanstore.BeanStore;
 import org.jboss.weld.context.beanstore.HashMapBeanStore;
-import io.silverware.microservices.annotations.MicroserviceScoped;
 
 import java.lang.annotation.Annotation;
-import javax.enterprise.context.ApplicationScoped;
 
 /**
  * @author <a href="mailto:marvenec@gmail.com">Martin Večeřa</a>
@@ -37,10 +36,6 @@ public class MicroserviceContext extends AbstractManagedContext {
 
    public MicroserviceContext(String contextId) {
       super(contextId, false);
-   }
-
-   public MicroserviceContext() {
-      this(RegistrySingletonProvider.STATIC_INSTANCE);
    }
 
    @Override

--- a/cdi-microservice-provider/src/main/java/io/silverware/microservices/providers/cdi/internal/DefaultMethodHandler.java
+++ b/cdi-microservice-provider/src/main/java/io/silverware/microservices/providers/cdi/internal/DefaultMethodHandler.java
@@ -53,12 +53,11 @@ public class DefaultMethodHandler extends MicroserviceMethodHandler {
    protected DefaultMethodHandler(final MicroserviceProxyBean proxyBean, final InjectionPoint injectionPoint) throws Exception {
       this.proxyBean = proxyBean;
       this.injectionPoint = injectionPoint;
-
       final Set<Annotation> qualifiers = proxyBean.getQualifiers().stream()
                                                   .filter(qualifier -> !matches(qualifier, MicroserviceReference.class))
                                                   .collect(Collectors.toSet());
-      final MicroserviceMetaData metaData = VersionResolver.createMicroserviceMetadata(proxyBean.getMicroserviceName(), proxyBean.getServiceInterface(), qualifiers, injectionPoint.getAnnotated().getAnnotations());
-
+      final MicroserviceMetaData metaData = VersionResolver.getInstance()
+                                                           .createMicroserviceMetadataForInjectionPoint(proxyBean.getMicroserviceName(), proxyBean.getServiceInterface(), qualifiers, injectionPoint.getAnnotated().getAnnotations());
       this.lookupStrategy = LookupStrategyFactory.getStrategy(proxyBean.getContext(), metaData, injectionPoint.getAnnotated().getAnnotations());
    }
 

--- a/cdi-microservice-provider/src/test/java/io/silverware/microservices/providers/cdi/CdiMicroserviceProviderVersionsLessNumbersTest.java
+++ b/cdi-microservice-provider/src/test/java/io/silverware/microservices/providers/cdi/CdiMicroserviceProviderVersionsLessNumbersTest.java
@@ -54,7 +54,7 @@ public class CdiMicroserviceProviderVersionsLessNumbersTest {
       Assert.assertEquals(result, "hello2bye1");
 
       platform.interrupt();
-      platform.join();
+      platform.join(0);
    }
 
    @Microservice("advanced")
@@ -62,10 +62,12 @@ public class CdiMicroserviceProviderVersionsLessNumbersTest {
 
       @Inject
       @MicroserviceReference
+      @MicroserviceVersion(api = "^2")
       private HelloVersion2Less micro1;
 
       @Inject
       @MicroserviceReference
+      @MicroserviceVersion(implementation = "~1")
       private ByeVersion1Less micro2;
 
       public void eventObserver(@Observes MicroservicesStartedEvent event) {
@@ -75,18 +77,16 @@ public class CdiMicroserviceProviderVersionsLessNumbersTest {
       }
    }
 
-   @MicroserviceVersion(api = "^2")
    public interface HelloVersion2Less {
       String hello();
    }
 
-   @MicroserviceVersion(api = "~1")
    public interface ByeVersion1Less {
       String bye();
    }
 
    @Microservice
-   @MicroserviceVersion(implementation = "1.6")
+   @MicroserviceVersion(implementation = "1.6", api = "1.6")
    public static class Version1LessMicroBeanLess implements HelloVersion2Less, ByeVersion1Less {
 
       @Override
@@ -101,7 +101,7 @@ public class CdiMicroserviceProviderVersionsLessNumbersTest {
    }
 
    @Microservice
-   @MicroserviceVersion(implementation = "2.4-SNAPSHOT")
+   @MicroserviceVersion(implementation = "2.4-SNAPSHOT", api = "2.4-SNAPSHOT")
    public static class Version2LessLessMicroBean implements HelloVersion2Less, ByeVersion1Less {
 
       @Override

--- a/cdi-microservice-provider/src/test/java/io/silverware/microservices/providers/cdi/CdiMicroserviceProviderVersionsTest.java
+++ b/cdi-microservice-provider/src/test/java/io/silverware/microservices/providers/cdi/CdiMicroserviceProviderVersionsTest.java
@@ -40,6 +40,8 @@ import javax.inject.Inject;
 public class CdiMicroserviceProviderVersionsTest {
 
    private static final Semaphore semaphore = new Semaphore(0);
+   public static final String VERSION_1 = "1.1.1";
+   public static final String VERSION_2 = "2.2.2";
    private static String result = "";
 
    @Test
@@ -54,7 +56,7 @@ public class CdiMicroserviceProviderVersionsTest {
       Assert.assertEquals(result, "hello2bye1");
 
       platform.interrupt();
-      platform.join();
+      platform.join(1);
    }
 
    @Microservice("basic")
@@ -62,10 +64,12 @@ public class CdiMicroserviceProviderVersionsTest {
 
       @Inject
       @MicroserviceReference
+      @MicroserviceVersion(api = VERSION_2)
       private HelloVersion2 micro1;
 
       @Inject
       @MicroserviceReference
+      @MicroserviceVersion(implementation = VERSION_1)
       private ByeVersion1 micro2;
 
       public void eventObserver(@Observes MicroservicesStartedEvent event) {
@@ -75,18 +79,16 @@ public class CdiMicroserviceProviderVersionsTest {
       }
    }
 
-   @MicroserviceVersion(api = "2.2.2")
    public interface HelloVersion2 {
       String hello();
    }
 
-   @MicroserviceVersion(api = "1.1.1")
    public interface ByeVersion1 {
       String bye();
    }
 
    @Microservice
-   @MicroserviceVersion(implementation = "1.1.1")
+   @MicroserviceVersion(implementation = VERSION_1, api = VERSION_1)
    public static class Version1MicroBean implements HelloVersion2, ByeVersion1 {
 
       @Override
@@ -101,7 +103,7 @@ public class CdiMicroserviceProviderVersionsTest {
    }
 
    @Microservice
-   @MicroserviceVersion(implementation = "2.2.2")
+   @MicroserviceVersion(implementation = VERSION_2, api = VERSION_2)
    public static class Version2MicroBean implements HelloVersion2, ByeVersion1 {
 
       @Override

--- a/cdi-microservice-provider/src/test/java/io/silverware/microservices/providers/cdi/util/VersionResolverTest.java
+++ b/cdi-microservice-provider/src/test/java/io/silverware/microservices/providers/cdi/util/VersionResolverTest.java
@@ -1,0 +1,240 @@
+/*
+ * -----------------------------------------------------------------------\
+ * SilverWare
+ *
+ * Copyright (C) 2010 - 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------/
+ */
+package io.silverware.microservices.providers.cdi.util;
+
+import static io.silverware.microservices.providers.cdi.util.VersionResolver.IMPLEMENTATION_VERSION;
+import static io.silverware.microservices.providers.cdi.util.VersionResolver.MORE_MICROSERVICE_VERSIONS_FOUND;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.silverware.microservices.MicroserviceMetaData;
+import io.silverware.microservices.annotations.MicroserviceVersion;
+
+import org.assertj.core.api.SoftAssertions;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import mockit.Expectations;
+
+/**
+ * This test check if version resolution works as is described in javadoc.
+ *
+ * @author Slavomír Krupa (slavomir.krupa@gmail.com)
+ */
+public class VersionResolverTest {
+
+   public static final String API = "API";
+   public static final String IMPL = "IMPL";
+
+   private VersionResolver vr;
+
+   @BeforeMethod
+   public void init() {
+      vr = VersionResolver.getInstance();
+   }
+
+   @Test
+   public void testCreateMicroserviceMetadata() throws Exception {
+      new Expectations(VersionResolver.class) {{
+         vr.resolveApiVersion((Class) any, (Set<Annotation>) any);
+         result = API;
+         vr.resolveImplementationVersion((Class) any, (Set<Annotation>) any);
+         result = IMPL;
+      }};
+
+      String name = UUID.randomUUID().toString();
+
+      MicroserviceMetaData microserviceMetadata = VersionResolver.getInstance().createMicroserviceMetadataForBeans(name, VersionResolverTest.class, Collections.emptySet(), new Annotation[0]);
+
+      SoftAssertions softly = new SoftAssertions();
+
+      softly.assertThat(microserviceMetadata.getName()).isEqualTo(name);
+      softly.assertThat(microserviceMetadata.getApiVersion()).isEqualTo(API);
+      softly.assertThat(microserviceMetadata.getImplVersion()).isEqualTo(IMPL);
+      softly.assertThat(microserviceMetadata.getType()).isEqualTo(VersionResolverTest.class);
+      softly.assertThat(microserviceMetadata.getAnnotations()).isEmpty();
+      softly.assertThat(microserviceMetadata.getQualifiers()).isEmpty();
+
+      softly.assertAll();
+
+   }
+
+   @Test
+   public void testIsEverythingTriggered() throws Exception {
+      new Expectations(VersionResolver.class) {{
+         vr.resolveVersionFromAnnotations((Stream<Annotation>) any, (Function<MicroserviceVersion, String>) any);
+         times = 2;
+         result = null;
+         vr.resolveVersionFromInterfacesClasses((Class) any, (Function<MicroserviceVersion, String>) any);
+         times = 1;
+         result = null;
+         vr.resolveVersionFromSuperClasses((Class) any, (Function<MicroserviceVersion, String>) any);
+         times = 1;
+         result = null;
+         vr.getClassVersionFromManifest((Class) any, (String) any);
+         times = 1;
+         result = null;
+
+      }};
+      Class clazz = VersionsHierarchy.WithBothVersionsOnClass.class;
+      String result = vr.resolveVersion(clazz, arrayAsSet(clazz.getAnnotations()), MicroserviceVersion::implementation, IMPLEMENTATION_VERSION);
+      assertThat(result).isNull();
+
+   }
+
+   @Test
+   public void testIsManifestTriggered() throws Exception {
+      new Expectations(VersionResolver.class) {{
+         vr.getClassVersionFromManifest((Class) any, (String) any);
+         times = 1;
+         result = API;
+
+      }};
+      Class clazz = VersionsHierarchy.WithoutVersions.class;
+      String result = vr.resolveApiVersion(clazz, arrayAsSet(clazz.getAnnotations()));
+      assertThat(result).isEqualTo(API);
+
+   }
+
+   @Test
+   public void testIsManifestTriggeredForInterface() throws Exception {
+      new Expectations(VersionResolver.class) {{
+         vr.getClassVersionFromManifest((Class) any, (String) any);
+         times = 1;
+         result = IMPL;
+
+      }};
+      Class clazz = VersionsHierarchy.WithoutVersion1.class;
+      String result = vr.resolveImplementationVersion(clazz, arrayAsSet(clazz.getAnnotations()));
+      assertThat(result).isEqualTo(IMPL);
+
+   }
+
+   @Test
+   public void testResolveVersionBasic() throws Exception {
+      final Class clazz = VersionsHierarchy.WithBothVersionsOnClass.class;
+
+      final String resultApi = vr.resolveApiVersion(clazz, arrayAsSet(clazz.getAnnotations()));
+      assertThat(resultApi).isEqualTo(VersionsHierarchy.WithBothVersionsOnClassApi);
+
+      final String resultImpl = vr.resolveImplementationVersion(clazz, arrayAsSet(clazz.getAnnotations()));
+      assertThat(resultImpl).isEqualTo(VersionsHierarchy.WithBothVersionsOnClassImpl);
+
+   }
+
+   @Test
+   public void testResolveVersionManually() throws Exception {
+      final Class clazz = VersionsHierarchy.WithBothVersionsOnClass.class;
+
+      final String resultApi = vr.resolveApiVersion(clazz, Collections.emptySet());
+      assertThat(resultApi).isEqualTo(VersionsHierarchy.WithBothVersionsOnClassApi);
+
+      final String resultImpl = vr.resolveImplementationVersion(clazz, Collections.emptySet());
+      assertThat(resultImpl).isEqualTo(VersionsHierarchy.WithBothVersionsOnClassImpl);
+
+   }
+
+   @Test
+   public void testResolveApiVersionFromParent() throws Exception {
+      final Class clazz = VersionsHierarchy.WithImplVersionOnClassAndApiVersionOnParent.class;
+
+      final String resultApi = vr.resolveApiVersion(clazz, arrayAsSet(clazz.getAnnotations()));
+      assertThat(resultApi).isEqualTo(VersionsHierarchy.WithBothVersionsOnClassApi);
+
+      final String resultImpl = vr.resolveImplementationVersion(clazz, arrayAsSet(clazz.getAnnotations()));
+      assertThat(resultImpl).isEqualTo(VersionsHierarchy.WithImplVersionOnClassAndApiVersionOnParent);
+
+   }
+
+   @Test
+   public void testResolveApiVersionFromInterface() throws Exception {
+      final Class clazz = VersionsHierarchy.WithImplVersionOnClassAndApiVersionOnInterface.class;
+
+      final String resultApi = vr.resolveApiVersion(clazz, arrayAsSet(clazz.getAnnotations()));
+      assertThat(resultApi).isEqualTo(VersionsHierarchy.WithVersionInterfaceApi);
+
+      final String resultImpl = vr.resolveImplementationVersion(clazz, arrayAsSet(clazz.getAnnotations()));
+      assertThat(resultImpl).isEqualTo(VersionsHierarchy.WithImplVersionOnClassAndApiVersionOnInterfaceImpl);
+   }
+
+   @Test
+   public void testResolveApiVersionFromClassAndImplVersionFromParent() throws Exception {
+      final Class clazz = VersionsHierarchy.WithApiVersionOnClassAndImplVersionOnParent.class;
+
+      final String resultApi = vr.resolveApiVersion(clazz, arrayAsSet(clazz.getAnnotations()));
+      assertThat(resultApi).isEqualTo(VersionsHierarchy.WithApiVersionOnClassAndImplVersionOnParent);
+
+      final String resultImpl = vr.resolveImplementationVersion(clazz, arrayAsSet(clazz.getAnnotations()));
+      assertThat(resultImpl).isEqualTo(VersionsHierarchy.WithBothVersionsOnClassImpl);
+   }
+
+   @Test
+   public void testResolveApiVersionOnClassAndImplVersionFromInterface() throws Exception {
+      final Class clazz = VersionsHierarchy.WithApiVersionOnClassAndImplVersionOnInterface.class;
+
+      final String resultApi = vr.resolveApiVersion(clazz, arrayAsSet(clazz.getAnnotations()));
+      assertThat(resultApi).isEqualTo(VersionsHierarchy.WithApiVersionOnClassAndImplVersionOnInterface);
+
+      final String resultImpl = vr.resolveImplementationVersion(clazz, arrayAsSet(clazz.getAnnotations()));
+      assertThat(resultImpl).isEqualTo(VersionsHierarchy.WithVersionInterfaceImpl);
+   }
+
+   @Test
+   public void testResolveBothVersionFromInterface() throws Exception {
+      final Class clazz = VersionsHierarchy.WithVersionsOnInterface.class;
+
+      final String resultApi = vr.resolveApiVersion(clazz, arrayAsSet(clazz.getAnnotations()));
+      assertThat(resultApi).isEqualTo(VersionsHierarchy.WithVersionInterfaceApi);
+
+      final String resultImpl = vr.resolveImplementationVersion(clazz, arrayAsSet(clazz.getAnnotations()));
+      assertThat(resultImpl).isEqualTo(VersionsHierarchy.WithVersionInterfaceImpl);
+   }
+
+   @Test
+   public void testResolveVersionPresentOnTwoInterfaces() throws Exception {
+      final Class clazz = VersionsHierarchy.WithVersionOn2Interfaces.class;
+
+      String versionString = MORE_MICROSERVICE_VERSIONS_FOUND.replace("%s.", "");
+      assertThatThrownBy(() -> vr.resolveApiVersion(clazz, arrayAsSet(clazz.getAnnotations())))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining(versionString)
+            .hasMessageContaining(VersionsHierarchy.WithVersionOn2Interfaces.class.getName());
+
+      assertThatThrownBy(() -> vr.resolveImplementationVersion(clazz, arrayAsSet(clazz.getAnnotations())))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining(versionString)
+            .hasMessageContaining(VersionsHierarchy.WithVersionOn2Interfaces.class.getName());
+
+   }
+
+   private Set<Annotation> arrayAsSet(final Annotation[] annotations) {
+      return new HashSet<>(asList(annotations));
+   }
+
+}

--- a/cdi-microservice-provider/src/test/java/io/silverware/microservices/providers/cdi/util/VersionsHierarchy.java
+++ b/cdi-microservice-provider/src/test/java/io/silverware/microservices/providers/cdi/util/VersionsHierarchy.java
@@ -1,0 +1,78 @@
+/*
+ * -----------------------------------------------------------------------\
+ * SilverWare
+ *  
+ * Copyright (C) 2010 - 2016 the original author or authors.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------/
+ */
+package io.silverware.microservices.providers.cdi.util;
+
+import io.silverware.microservices.annotations.MicroserviceVersion;
+
+/**
+ * This class contains hierarchies for testing version resolution.
+ *
+ * @author Slavomír Krupa (slavomir.krupa@gmail.com)
+ */
+class VersionsHierarchy {
+   static final String WithBothVersionsOnClassApi = "WithBothVersionsOnClassApi";
+   static final String WithBothVersionsOnClassImpl = "WithBothVersionsOnClassImpl";
+
+   static final String WithVersionInterfaceApi = "WithVersionInterfaceApi";
+   static final String WithVersionInterfaceImpl = "WithVersionInterfaceImpl";
+
+   static final String WithVersionInterfaceApi2 = "WithVersionInterfaceApi2";
+   static final String WithVersionInterfaceImpl2 = "WithVersionInterfaceImpl2";
+
+   static final String WithImplVersionOnClassAndApiVersionOnInterfaceImpl = "WithImplVersionOnClassAndApiVersionOnInterfaceImpl";
+   static final String WithImplVersionOnClassAndApiVersionOnParent = "WithImplVersionOnClassAndApiVersionOnParent";
+
+   static final String WithApiVersionOnClassAndImplVersionOnParent = "WithApiVersionOnClassAndImplVersionOnParent";
+   static final String WithApiVersionOnClassAndImplVersionOnInterface = "WithApiVersionOnClassAndImplVersionOnInterface";
+
+   // @formatter:off
+   interface WithoutVersion1 {  }
+
+   interface WithoutVersion2 {  }
+
+   @MicroserviceVersion(implementation = WithVersionInterfaceImpl, api = WithVersionInterfaceApi)
+   interface WithVersionInterface {  }
+
+   @MicroserviceVersion(implementation = WithVersionInterfaceApi2, api = WithVersionInterfaceImpl2)
+   interface WithVersionInterface2  {  }
+
+
+   static class WithVersionsOnInterface implements WithVersionInterface,WithoutVersion1, WithoutVersion2 {   }
+
+   static class WithoutVersions implements WithoutVersion1, WithoutVersion2 {   }
+
+   @MicroserviceVersion(api = WithBothVersionsOnClassApi, implementation = WithBothVersionsOnClassImpl)
+   static class WithBothVersionsOnClass implements WithoutVersion2, WithVersionInterface {   }
+
+   @MicroserviceVersion(api = WithApiVersionOnClassAndImplVersionOnParent)
+   static class WithApiVersionOnClassAndImplVersionOnParent extends WithBothVersionsOnClass implements WithoutVersion2 {   }
+
+   @MicroserviceVersion(implementation = WithImplVersionOnClassAndApiVersionOnParent)
+   static class WithImplVersionOnClassAndApiVersionOnParent extends WithBothVersionsOnClass  implements WithoutVersion2 {   }
+
+   @MicroserviceVersion(api = WithApiVersionOnClassAndImplVersionOnInterface)
+   static class WithApiVersionOnClassAndImplVersionOnInterface extends WithBothVersionsOnClass implements WithoutVersion2, WithVersionInterface {   }
+
+   @MicroserviceVersion(implementation = WithImplVersionOnClassAndApiVersionOnInterfaceImpl)
+   static class WithImplVersionOnClassAndApiVersionOnInterface extends WithBothVersionsOnClass  implements WithoutVersion2,WithVersionInterface {   }
+
+   static class WithVersionOn2Interfaces implements WithVersionInterface, WithVersionInterface2 {   }
+   // @formatter:on
+}

--- a/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/RemoteServiceHandle.java
+++ b/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/RemoteServiceHandle.java
@@ -19,6 +19,9 @@
  */
 package io.silverware.microservices.providers.cluster;
 
+import static io.silverware.microservices.providers.cluster.internal.exception.SilverWareClusteringException.SilverWareClusteringError.INVOCATION_EXCEPTION;
+import static io.silverware.microservices.providers.cluster.internal.exception.SilverWareClusteringException.SilverWareClusteringError.PROCESSING_ERROR;
+
 import io.silverware.microservices.Context;
 import io.silverware.microservices.MicroserviceMetaData;
 import io.silverware.microservices.providers.cluster.internal.JgroupsMessageSender;
@@ -27,8 +30,7 @@ import io.silverware.microservices.providers.cluster.internal.message.request.Mi
 import io.silverware.microservices.providers.cluster.internal.message.response.MicroserviceRemoteCallResponse;
 import io.silverware.microservices.silver.cluster.Invocation;
 import io.silverware.microservices.silver.cluster.ServiceHandle;
-import javassist.util.proxy.MethodHandler;
-import javassist.util.proxy.ProxyFactory;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jgroups.Address;
@@ -36,8 +38,8 @@ import org.jgroups.Address;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-import static io.silverware.microservices.providers.cluster.internal.exception.SilverWareClusteringException.SilverWareClusteringError.INVOCATION_EXCEPTION;
-import static io.silverware.microservices.providers.cluster.internal.exception.SilverWareClusteringException.SilverWareClusteringError.PROCESSING_ERROR;
+import javassist.util.proxy.MethodHandler;
+import javassist.util.proxy.ProxyFactory;
 
 /**
  * This class represent remote handle which allows invocation remote services
@@ -90,6 +92,12 @@ public class RemoteServiceHandle implements ServiceHandle, MethodHandler {
          return toString();
       } else if ("hashCode".equals(method) && paramCount == 0) {
          return this.hashCode();
+      } else if ("finalize".equals(method) && paramCount == 0) {
+         try {
+            this.finalize();
+         } catch (Throwable throwable) {
+            throw new RuntimeException(throwable);
+         }
       } else if ("equals".equals(method) && paramCount == 1) {
          return this.equals(params[0]);
       } else if ("getClass".equals(method) && paramCount == 0) {

--- a/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/JgroupsMessageSender.java
+++ b/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/JgroupsMessageSender.java
@@ -144,4 +144,8 @@ public class JgroupsMessageSender {
       return this.dispatcher.sendMessage(new Message(address, Util.objectToByteBuffer(content)), SYNC_OPTIONS);
    }
 
+   public boolean isEmptyCluster() {
+      return this.getOtherMembersAddresses().isEmpty();
+   }
+
 }

--- a/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/message/responder/MicroserviceSearchResponder.java
+++ b/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/message/responder/MicroserviceSearchResponder.java
@@ -56,7 +56,7 @@ public class MicroserviceSearchResponder extends AbstractResponder<MicroserviceM
    @Override
    MicroserviceSearchResponse doProcessMessage(Address source, MicroserviceMetaData query) {
       try {
-         List<LocalServiceHandle> localServiceHandles = context.assureHandles(query);
+         List<LocalServiceHandle> localServiceHandles = context.assureLocalHandles(query);
          List<LocalServiceHandle> serviceHandles = filterVersionCompatible(localServiceHandles, query);
 
          if (serviceHandles.size() > 1) {
@@ -64,12 +64,10 @@ public class MicroserviceSearchResponder extends AbstractResponder<MicroserviceM
             return new MicroserviceSearchResponse(MULTIPLE_IMPLEMENTATIONS_FOUND);
          }
          if (serviceHandles.isEmpty()) {
-            if (log.isTraceEnabled()) {
-               log.trace("No services found for metadata: {} ", query);
-            }
+            log.trace("No services found for metadata: {} ", query);
             return new MicroserviceSearchResponse(localServiceHandles.isEmpty() ? NOT_FOUND : WRONG_VERSION);
-         } else if (log.isTraceEnabled()) {
-            log.trace("{} services found for {}", serviceHandles.size(), query);
+         } else {
+            log.trace("{} services found for {}", serviceHandles, query);
          }
          return new MicroserviceSearchResponse(serviceHandles.get(0).getHandle(), FOUND);
       } catch (Throwable e) {

--- a/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/message/response/MicroserviceSearchResponse.java
+++ b/cluster-microservice-provider/src/main/java/io/silverware/microservices/providers/cluster/internal/message/response/MicroserviceSearchResponse.java
@@ -67,4 +67,12 @@ public class MicroserviceSearchResponse implements Serializable {
    public Integer getHandle() {
       return handle;
    }
+
+   @Override
+   public String toString() {
+      return "MicroserviceSearchResponse{" +
+            "handle=" + handle +
+            ", result=" + result +
+            '}';
+   }
 }

--- a/cluster-microservice-provider/src/test/java/io/silverware/microservices/providers/cluster/ClusterMicroserviceProviderTest.java
+++ b/cluster-microservice-provider/src/test/java/io/silverware/microservices/providers/cluster/ClusterMicroserviceProviderTest.java
@@ -56,7 +56,7 @@ public class ClusterMicroserviceProviderTest {
 
    @Test
    public void testLookupMicroservice() throws Exception {
-      Set<ServiceHandle> mockHandles = Util.createSetFrom(Util.createHandle("1"), Util.createHandle("2"));
+      Set<ServiceHandle> mockHandles = Util.createSetFrom(Util.createHandle(1), Util.createHandle(2));
       Set<Object> services = Util.createSetFrom(new Object(), new Object());
 
       new Expectations() {{

--- a/cluster-microservice-provider/src/test/java/io/silverware/microservices/providers/cluster/Util.java
+++ b/cluster-microservice-provider/src/test/java/io/silverware/microservices/providers/cluster/Util.java
@@ -20,7 +20,6 @@
 package io.silverware.microservices.providers.cluster;
 
 import io.silverware.microservices.providers.cluster.internal.RemoteServiceHandleStoreTest;
-import io.silverware.microservices.silver.cluster.LocalServiceHandle;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -32,8 +31,8 @@ import java.util.Set;
  * @author Slavomír Krupa (slavomir.krupa@gmail.com)
  */
 public class Util {
-   public static LocalServiceHandle createHandle(String host) {
-      return new LocalServiceHandle(host, RemoteServiceHandleStoreTest.META_DATA, new Object());
+   public static RemoteServiceHandle createHandle(int handle) {
+      return new RemoteServiceHandle(org.jgroups.util.UUID.randomUUID(), 1, null, RemoteServiceHandleStoreTest.META_DATA);
    }
 
    public static <T> Set<T> createSetFrom(T... components) {

--- a/cluster-microservice-provider/src/test/java/io/silverware/microservices/providers/cluster/internal/RemoteServiceHandleStoreTest.java
+++ b/cluster-microservice-provider/src/test/java/io/silverware/microservices/providers/cluster/internal/RemoteServiceHandleStoreTest.java
@@ -22,8 +22,8 @@ package io.silverware.microservices.providers.cluster.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.silverware.microservices.MicroserviceMetaData;
+import io.silverware.microservices.providers.cluster.RemoteServiceHandle;
 import io.silverware.microservices.providers.cluster.Util;
-import io.silverware.microservices.silver.cluster.LocalServiceHandle;
 import io.silverware.microservices.silver.cluster.RemoteServiceHandlesStore;
 import io.silverware.microservices.silver.cluster.ServiceHandle;
 
@@ -45,31 +45,31 @@ public class RemoteServiceHandleStoreTest {
    private static final Set<Annotation> ANNOTATIONS = new HashSet<>(Arrays.asList(RemoteServiceHandleStoreTest.class.getClass().getAnnotations()));
 
    public static final MicroserviceMetaData META_DATA = new MicroserviceMetaData(RemoteServiceHandleStoreTest.class.getName(), RemoteServiceHandleStoreTest.class, ANNOTATIONS, ANNOTATIONS, VERSION, VERSION);
-   public static final LocalServiceHandle SERVICE_HANDLE = Util.createHandle("host");
+   public static final RemoteServiceHandle SERVICE_HANDLE = Util.createHandle(101);
 
    @Test
    public void addSingleHandle() {
       RemoteServiceHandlesStore store = new RemoteServiceHandlesStore();
       store.addHandle(META_DATA, SERVICE_HANDLE);
       Set<Object> services = store.getServices(META_DATA);
-      assertThat(services).containsOnly(SERVICE_HANDLE.getProxy());
+      assertThat(services).containsOnly(SERVICE_HANDLE);
    }
 
    @Test
    public void testRemoveHandlesByHost() {
       RemoteServiceHandlesStore store = new RemoteServiceHandlesStore();
-      Set<ServiceHandle> handles = Util.createSetFrom(Util.createHandle("1"), Util.createHandle("2"), SERVICE_HANDLE);
+      Set<ServiceHandle> handles = Util.createSetFrom(Util.createHandle(1), Util.createHandle(2), SERVICE_HANDLE);
       store.addHandles(META_DATA, handles);
-      store.keepHandlesFor(Util.createSetFrom("host"));
+      store.keepHandlesFor(Util.createSetFrom(SERVICE_HANDLE.getHost()));
 
       Set<Object> services = store.getServices(META_DATA);
-      assertThat(services).containsOnly(SERVICE_HANDLE.getProxy());
+      assertThat(services).containsExactly(SERVICE_HANDLE);
    }
 
    @Test
    public void testAddHandlesCollectionAfterOneHandle() {
       RemoteServiceHandlesStore store = new RemoteServiceHandlesStore();
-      Set<ServiceHandle> handles = Util.createSetFrom(Util.createHandle("1"), Util.createHandle("2"));
+      Set<ServiceHandle> handles = Util.createSetFrom(Util.createHandle(1), Util.createHandle(2));
       store.addHandle(META_DATA, SERVICE_HANDLE);
       store.addHandles(META_DATA, handles);
       Set<Object> services = store.getServices(META_DATA);
@@ -79,7 +79,7 @@ public class RemoteServiceHandleStoreTest {
    @Test
    public void testAddOneHandleAfterHandlesCollection() {
       RemoteServiceHandlesStore store = new RemoteServiceHandlesStore();
-      Set<ServiceHandle> handles = Util.createSetFrom(Util.createHandle("1"), Util.createHandle("2"));
+      Set<ServiceHandle> handles = Util.createSetFrom(Util.createHandle(1), Util.createHandle(2));
       store.addHandles(META_DATA, handles);
       store.addHandle(META_DATA, SERVICE_HANDLE);
       Set<Object> services = store.getServices(META_DATA);

--- a/http-invoker-microservice-provider/src/main/java/io/silverware/microservices/providers/http/invoker/HttpInvokerMicroserviceProvider.java
+++ b/http-invoker-microservice-provider/src/main/java/io/silverware/microservices/providers/http/invoker/HttpInvokerMicroserviceProvider.java
@@ -46,8 +46,6 @@ public class HttpInvokerMicroserviceProvider implements MicroserviceProvider, Ht
    @Override
    public void initialize(final Context context) {
       this.context = context;
-      HttpInvokerServlet.setContext(context);
-
       context.getProperties().putIfAbsent(INVOKER_URL, "invoker");
    }
 
@@ -60,7 +58,8 @@ public class HttpInvokerMicroserviceProvider implements MicroserviceProvider, Ht
    public void run() {
       try {
          log.info("Hello from Http Invoker microservice provider!");
-
+         Utils.waitForCDIProvider(context);
+         HttpInvokerServlet.setContext(context);
          try {
             if (log.isDebugEnabled()) {
                log.debug("Waiting for the Http Microservice provider.");

--- a/http-invoker-microservice-provider/src/main/java/io/silverware/microservices/providers/http/invoker/internal/HttpServiceHandle.java
+++ b/http-invoker-microservice-provider/src/main/java/io/silverware/microservices/providers/http/invoker/internal/HttpServiceHandle.java
@@ -1,0 +1,86 @@
+/*
+ * -----------------------------------------------------------------------\
+ * SilverWare
+ *  
+ * Copyright (C) 2010 - 2013 the original author or authors.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------/
+ */
+package io.silverware.microservices.providers.http.invoker.internal;
+
+import io.silverware.microservices.Context;
+import io.silverware.microservices.silver.HttpInvokerSilverService;
+import io.silverware.microservices.silver.cluster.Invocation;
+
+import com.cedarsoftware.util.io.JsonReader;
+import com.cedarsoftware.util.io.JsonWriter;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+/**
+ * Can act as a Http Invoker client to invoke the remote Microservice.
+ *
+ * @author Slavomír Krupa (slavomir.krupa@gmail.com)
+ */
+public class HttpServiceHandle {
+
+   private final int handle;
+
+   private final String host;
+
+   public HttpServiceHandle(final String host, int handle) {
+      this.host = host;
+      this.handle = handle;
+   }
+
+   public int getHandle() {
+      return handle;
+   }
+
+   /**
+    * Context is not used
+    *
+    * @param context
+    *       Local microservice context
+    * @param method
+    *       name of the method to be invoked
+    * @param paramTypes
+    *       parameters types
+    * @param params
+    *       parameters of method called
+    * @return result of the invocation
+    * @throws Exception
+    *       in case of any error
+    */
+   public Object invoke(final Context context, final String method, final Class[] paramTypes, final Object[] params) throws Exception {
+      String urlBase = "http://" + host + "/" + context.getProperties().get(HttpInvokerSilverService.INVOKER_URL) + "/invoke";
+
+      HttpURLConnection con = (HttpURLConnection) new URL(urlBase).openConnection();
+      con.setRequestMethod("POST");
+      con.setDoInput(true);
+      con.setDoOutput(true);
+      con.connect();
+
+      Invocation invocation = new Invocation(handle, method, paramTypes, params);
+      JsonWriter jsonWriter = new JsonWriter(con.getOutputStream());
+      jsonWriter.write(invocation);
+      JsonReader jsonReader = new JsonReader(con.getInputStream());
+      Object response = jsonReader.readObject();
+
+      con.disconnect();
+
+      return response;
+   }
+}

--- a/microservices-bom/pom.xml
+++ b/microservices-bom/pom.xml
@@ -58,7 +58,7 @@
       <version.testng>6.9.10</version.testng>
       <version.apache.camel>2.16.1</version.apache.camel>
       <version.slf4j>1.7.13</version.slf4j>
-      <version.weld>2.3.2.Final</version.weld>
+      <version.weld>2.4.1.Final</version.weld>
       <version.ejb.api>3.0</version.ejb.api>
       <version.jboss.logging>3.3.0.Final</version.jboss.logging>
       <version.jgroups>3.6.6.Final</version.jgroups>

--- a/microservices/src/main/java/io/silverware/microservices/Boot.java
+++ b/microservices/src/main/java/io/silverware/microservices/Boot.java
@@ -74,10 +74,6 @@ public final class Boot {
 
       log.info("Goodbye.");
       logFlush(); // this is needed for Ctrl+C termination
-      // if we had clean up everything. Why should we end with non-zero code?
-      if (Boolean.parseBoolean(String.valueOf(initialContext.getProperties().get(SHUTDOWN_HOOK)))) {
-         System.exit(0);
-      }
    }
 
    /**
@@ -97,12 +93,15 @@ public final class Boot {
 
    /**
     * Load custom properties from filepath
-    * @param propertiesFile file with properties which will be loaded
+    *
+    * @param propertiesFile
+    *       file with properties which will be loaded
     * @return Properties from given file path
     */
 
    private static Properties loadProperties(final File propertiesFile) {
       log.info("Loading configuration from file {}.", propertiesFile.getAbsolutePath());
+
       Properties props = new Properties();
       try (FileInputStream fis = new FileInputStream(propertiesFile)) {
          props.load(fis);

--- a/microservices/src/main/java/io/silverware/microservices/MicroserviceMetaData.java
+++ b/microservices/src/main/java/io/silverware/microservices/MicroserviceMetaData.java
@@ -155,35 +155,34 @@ public final class MicroserviceMetaData implements Serializable {
    }
 
    @Override
-   public boolean equals(Object o) {
+   public boolean equals(final Object o) {
       if (this == o) {
          return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof MicroserviceMetaData)) {
          return false;
       }
 
-      MicroserviceMetaData that = (MicroserviceMetaData) o;
+      final MicroserviceMetaData that = (MicroserviceMetaData) o;
 
-      if (!name.equals(that.name)) {
+      if (!getName().equals(that.getName())) {
          return false;
       }
-      if (!type.equals(that.type)) {
+      if (!getType().equals(that.getType())) {
          return false;
       }
-      if (qualifiers != null ? !qualifiers.equals(that.qualifiers) : that.qualifiers != null) {
+      if (getQualifiers() != null ? !getQualifiers().equals(that.getQualifiers()) : that.getQualifiers() != null) {
          return false;
       }
-      return (annotations != null ? !annotations.equals(that.annotations) : that.annotations != null);
-
+      return getAnnotations() != null ? getAnnotations().equals(that.getAnnotations()) : that.getAnnotations() == null;
    }
 
    @Override
    public int hashCode() {
-      int result = name.hashCode();
-      result = 31 * result + type.hashCode();
-      result = 31 * result + (qualifiers != null ? qualifiers.hashCode() : 0);
-      result = 31 * result + (annotations != null ? annotations.hashCode() : 0);
+      int result = getName().hashCode();
+      result = 31 * result + getType().hashCode();
+      result = 31 * result + (getQualifiers() != null ? getQualifiers().hashCode() : 0);
+      result = 31 * result + (getAnnotations() != null ? getAnnotations().hashCode() : 0);
       return result;
    }
 
@@ -197,11 +196,24 @@ public final class MicroserviceMetaData implements Serializable {
     * Compares api version from query with a implementation version of a this object resolve whether it satisfies.
     *
     * @param query
-    *       other metada object which specify verion
+    *       other metada object which specify version
     * @return boolean representing whether this object satisfies a query
     */
    public boolean satisfies(MicroserviceMetaData query) {
-      return equals(query) && VersionComparator.forVersion(this.implVersion).satisfies(query.apiVersion);
+      return equals(query) &&
+            satisfiesJustVersion(query);
+   }
+
+   /**
+    * Compares api version from query with a implementation version of a this object resolve whether it satisfies.
+    *
+    * @param query
+    *       other metada object which specify version
+    * @return boolean representing whether this object satisfies just version comparision
+    */
+   public boolean satisfiesJustVersion(MicroserviceMetaData query) {
+      return VersionComparator.forVersion(query, this.implVersion).satisfies(query.implVersion)
+            && VersionComparator.forVersion(query, this.apiVersion).satisfies(query.apiVersion);
    }
 
    /**

--- a/microservices/src/main/java/io/silverware/microservices/silver/cluster/Invocation.java
+++ b/microservices/src/main/java/io/silverware/microservices/silver/cluster/Invocation.java
@@ -21,11 +21,11 @@ package io.silverware.microservices.silver.cluster;
 
 import io.silverware.microservices.Context;
 import io.silverware.microservices.SilverWareException;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.Serializable;
-import java.lang.reflect.Method;
 import java.util.Arrays;
 
 /**
@@ -112,23 +112,19 @@ public class Invocation implements Serializable {
    /**
     * Invokes a method with given context
     *
-    * @param context context which will be used to invoke method
+    * @param context
+    *       context which will be used to invoke method
     * @return result of the invocation
-    * @throws Exception when some error occurs
+    * @throws Exception
+    *       when some error occurs
     */
    public Object invoke(final Context context) throws Exception {
-      if (log.isTraceEnabled()) {
-         log.trace("Invoking Microservice with invocation {}.", toString());
-      }
-
-      final LocalServiceHandle serviceHandle = context.getInboundServiceHandle(handle);
-
+      log.trace("Invoking Microservice with invocation {}.", this);
+      final LocalServiceHandle serviceHandle = context.getLocalServiceHandle(handle);
       if (serviceHandle == null) {
          throw new SilverWareException(String.format("Handle no. %d. No such handle found.", getHandle()));
       }
-
-      final Method method = serviceHandle.getProxy().getClass().getDeclaredMethod(getMethod(), paramTypes);
-      return method.invoke(serviceHandle.getProxy(), params);
+      return serviceHandle.invoke(context, this.method, this.paramTypes, this.params);
    }
 
 }

--- a/microservices/src/main/java/io/silverware/microservices/silver/services/LookupStrategyFactory.java
+++ b/microservices/src/main/java/io/silverware/microservices/silver/services/LookupStrategyFactory.java
@@ -22,7 +22,7 @@ package io.silverware.microservices.silver.services;
 import io.silverware.microservices.Context;
 import io.silverware.microservices.MicroserviceMetaData;
 import io.silverware.microservices.annotations.InvocationPolicy;
-import io.silverware.microservices.silver.services.lookup.RoundRobinLookupStrategy;
+import io.silverware.microservices.silver.services.lookup.FirstFoundLocalLookupStrategy;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -72,7 +72,7 @@ public class LookupStrategyFactory {
       }
 
       if (strategy == null) {
-         strategy = new RoundRobinLookupStrategy();
+         strategy = new FirstFoundLocalLookupStrategy();
          strategy.initialize(context, metaData, options);
       }
 

--- a/microservices/src/test/java/io/silverware/microservices/util/VersionComparatorTest.java
+++ b/microservices/src/test/java/io/silverware/microservices/util/VersionComparatorTest.java
@@ -48,7 +48,7 @@ public class VersionComparatorTest {
 
    @Test(dataProvider = SUCCESS)
    public void testSatisfiesConditionSuccess(String condition) throws Exception {
-      assertThat(VersionComparator.forVersion(VERSION).satisfies(condition)).as(DESCRIPTION, VERSION, " ", condition).isTrue();
+      assertThat(VersionComparator.forVersion(null, VERSION).satisfies(condition)).as(DESCRIPTION, VERSION, " ", condition).isTrue();
    }
 
    @DataProvider(name = FAIL)
@@ -58,7 +58,7 @@ public class VersionComparatorTest {
 
    @Test(dataProvider = FAIL)
    public void testSatisfiesConditionFails(String condition) throws Exception {
-      assertThat(VersionComparator.forVersion(VERSION).satisfies(condition)).as(DESCRIPTION, VERSION, " not ", condition).isFalse();
+      assertThat(VersionComparator.forVersion(null, VERSION).satisfies(condition)).as(DESCRIPTION, VERSION, " not ", condition).isFalse();
    }
 
    @DataProvider(name = SUCCESS_LESS_DIGITS)
@@ -68,7 +68,7 @@ public class VersionComparatorTest {
 
    @Test(dataProvider = SUCCESS_LESS_DIGITS)
    public void testSatisfiesConditionWithLessDigitsSuccess(String condition) throws Exception {
-      assertThat(VersionComparator.forVersion(MINOR_VERSION_SNAPSHOT).satisfies(condition)).as(DESCRIPTION, MINOR_VERSION_SNAPSHOT, " ", condition).isTrue();
+      assertThat(VersionComparator.forVersion(null, MINOR_VERSION_SNAPSHOT).satisfies(condition)).as(DESCRIPTION, MINOR_VERSION_SNAPSHOT, " ", condition).isTrue();
    }
 
    @DataProvider(name = SUCCESS_MAJOR_SNAPSHOT)
@@ -78,7 +78,7 @@ public class VersionComparatorTest {
 
    @Test(dataProvider = SUCCESS_MAJOR_SNAPSHOT)
    public void testSatisfiesConditionMajorSnapshotSuccess(String condition) throws Exception {
-      assertThat(VersionComparator.forVersion(MAJOR_VERSION_SNAPSHOT).satisfies(condition)).as(DESCRIPTION, MAJOR_VERSION_SNAPSHOT, " ", condition).isTrue();
+      assertThat(VersionComparator.forVersion(null, MAJOR_VERSION_SNAPSHOT).satisfies(condition)).as(DESCRIPTION, MAJOR_VERSION_SNAPSHOT, " ", condition).isTrue();
    }
 
 }


### PR DESCRIPTION
* version resolution now use queries from injection points
* add tests for version resolution and fix founded bugs
* beans metadata is now stored in context and are searchable by `Predicate`
* make the local service handle really local
* introduce HttpServiceHandle for remote invocations in HttpInvoker
* move logic from initialization to run phase in cluster provider
* add wait for cdi provider before joining Jgroups channel
* remove system exit (broken on windows platform :/)
* Update Weld to 2.4.1.Final