### PR TITLE
Update Hystrix version to 1.5.9

### DIFF
--- a/hystrix-microservice-provider/src/main/java/io/silverware/microservices/providers/hystrix/configuration/SetterFactory.java
+++ b/hystrix-microservice-provider/src/main/java/io/silverware/microservices/providers/hystrix/configuration/SetterFactory.java
@@ -211,6 +211,11 @@ public class SetterFactory {
          setter.withMaximumSize(Integer.parseInt(maximumSize));
       }
 
+      String allowMaximumSizeToDivergeFromCoreSize = threadPoolProperties.get(ThreadPoolProperties.ALLOW_MAXIMUM_SIZE_TO_DIVERGE_FROM_CORE_SIZE);
+      if (allowMaximumSizeToDivergeFromCoreSize != null) {
+         setter.withAllowMaximumSizeToDivergeFromCoreSize(Boolean.parseBoolean(allowMaximumSizeToDivergeFromCoreSize));
+      }
+
       String keepAliveTimeMinutes = threadPoolProperties.get(ThreadPoolProperties.KEEP_ALIVE_TIME_MINUTES);
       if (keepAliveTimeMinutes != null) {
          setter.withKeepAliveTimeMinutes(Integer.parseInt(keepAliveTimeMinutes));

--- a/hystrix-microservice-provider/src/main/java/io/silverware/microservices/providers/hystrix/configuration/ThreadPoolProperties.java
+++ b/hystrix-microservice-provider/src/main/java/io/silverware/microservices/providers/hystrix/configuration/ThreadPoolProperties.java
@@ -28,6 +28,7 @@ public interface ThreadPoolProperties {
 
    String CORE_SIZE = "coreSize";
    String MAXIMUM_SIZE = "maximumSize";
+   String ALLOW_MAXIMUM_SIZE_TO_DIVERGE_FROM_CORE_SIZE = "allowMaximumSizeToDivergeFromCoreSize";
    String KEEP_ALIVE_TIME_MINUTES = "keepAliveTimeMinutes";
    String MAX_QUEUE_SIZE = "maxQueueSize";
    String METRICS_ROLLING_STATS_NUM_BUCKETS = "metrics.rollingStats.numBuckets";

--- a/hystrix-microservice-provider/src/test/java/io/silverware/microservices/providers/hystrix/configuration/AnnotationScannerLowLevelInterfaceTest.java
+++ b/hystrix-microservice-provider/src/test/java/io/silverware/microservices/providers/hystrix/configuration/AnnotationScannerLowLevelInterfaceTest.java
@@ -68,6 +68,8 @@ public class AnnotationScannerLowLevelInterfaceTest extends AnnotationScannerTes
    private static final String REQUEST_LOG_ENABLED = "false";
 
    private static final String CORE_SIZE = "10";
+   private static final String MAXIMUM_SIZE = "20";
+   private static final String ALLOW_MAXIMUM_SIZE_TO_DIVERGE_FROM_CORE_SIZE = "true";
    private static final String KEEP_ALIVE_TIME_MINUTES = "5";
    private static final String MAX_QUEUE_SIZE = "20";
    private static final String QUEUE_SIZE_REJECTION_THRESHOLD = "42";
@@ -171,6 +173,8 @@ public class AnnotationScannerLowLevelInterfaceTest extends AnnotationScannerTes
 
       assertions = new SoftAssertions();
       assertions.assertThat(threadPoolProperties).containsEntry(ThreadPoolProperties.CORE_SIZE, CORE_SIZE);
+      assertions.assertThat(threadPoolProperties).containsEntry(ThreadPoolProperties.MAXIMUM_SIZE, MAXIMUM_SIZE);
+      assertions.assertThat(threadPoolProperties).containsEntry(ThreadPoolProperties.ALLOW_MAXIMUM_SIZE_TO_DIVERGE_FROM_CORE_SIZE, ALLOW_MAXIMUM_SIZE_TO_DIVERGE_FROM_CORE_SIZE);
       assertions.assertThat(threadPoolProperties).containsEntry(ThreadPoolProperties.KEEP_ALIVE_TIME_MINUTES, KEEP_ALIVE_TIME_MINUTES);
       assertions.assertThat(threadPoolProperties).containsEntry(ThreadPoolProperties.MAX_QUEUE_SIZE, MAX_QUEUE_SIZE);
       assertions.assertThat(threadPoolProperties).containsEntry(ThreadPoolProperties.METRICS_ROLLING_STATS_NUM_BUCKETS, METRICS_ROLLING_STATS_NUM_BUCKETS);
@@ -349,6 +353,8 @@ public class AnnotationScannerLowLevelInterfaceTest extends AnnotationScannerTes
             },
             threadPoolProperties = {
                   @HystrixProperty(name = ThreadPoolProperties.CORE_SIZE, value = CORE_SIZE),
+                  @HystrixProperty(name = ThreadPoolProperties.MAXIMUM_SIZE, value = MAXIMUM_SIZE),
+                  @HystrixProperty(name = ThreadPoolProperties.ALLOW_MAXIMUM_SIZE_TO_DIVERGE_FROM_CORE_SIZE, value = ALLOW_MAXIMUM_SIZE_TO_DIVERGE_FROM_CORE_SIZE),
                   @HystrixProperty(name = ThreadPoolProperties.KEEP_ALIVE_TIME_MINUTES, value = KEEP_ALIVE_TIME_MINUTES),
                   @HystrixProperty(name = ThreadPoolProperties.MAX_QUEUE_SIZE, value = MAX_QUEUE_SIZE),
                   @HystrixProperty(name = ThreadPoolProperties.METRICS_ROLLING_STATS_NUM_BUCKETS, value = METRICS_ROLLING_STATS_NUM_BUCKETS),

--- a/microservices-bom/pom.xml
+++ b/microservices-bom/pom.xml
@@ -77,7 +77,7 @@
       <version.assertj>3.5.2</version.assertj>
       <version.resteasy>3.0.19.Final</version.resteasy>
       <version.sem.ver>2.0.1</version.sem.ver>
-      <version.hystrix>1.5.8</version.hystrix>
+      <version.hystrix>1.5.9</version.hystrix>
       <version.mockito>2.2.22</version.mockito>
       <java.level>1.8</java.level>
    </properties>


### PR DESCRIPTION
This updates Hystrix version to 1.5.9 and adds forgotten thread pool properties that have been added in previous versions.