### PR TITLE
Clean up and update dependencies

### DIFF
--- a/activemq-microservice-provider/pom.xml
+++ b/activemq-microservice-provider/pom.xml
@@ -26,18 +26,15 @@
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-jms-client</artifactId>
-         <version>1.2.0</version>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-jms-server</artifactId>
-         <version>1.2.0</version>
          <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>activemq-all</artifactId>
-         <version>5.13.2</version>
          <scope>test</scope>
       </dependency>
    </dependencies>

--- a/camel-cdi-integration/src/main/java/io/silverware/microservices/providers/camel/CamelCdiContextFactory.java
+++ b/camel-cdi-integration/src/main/java/io/silverware/microservices/providers/camel/CamelCdiContextFactory.java
@@ -2,7 +2,7 @@
  * -----------------------------------------------------------------------\
  * SilverWare
  *  
- * Copyright (C) 2015 the original author or authors.
+ * Copyright (C) 2015 - 2017 the original author or authors.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import io.silverware.microservices.silver.CdiSilverService;
 import io.silverware.microservices.util.Utils;
 
 import org.apache.camel.CamelContext;
-import org.apache.camel.cdi.internal.CamelContextMap;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -62,8 +61,7 @@ public class CamelCdiContextFactory implements CamelContextFactory {
          if (cdiSilverService.isDeployed()) {
             log.info("CDI SilverService connected successfully!");
 
-            CamelContextMap camelContextMap = cdiSilverService.findByType(CamelContextMap.class);
-            return camelContextMap.getCamelContext("camel-1");
+            return cdiSilverService.findByType(CamelContext.class);
          } else {
             log.warn("CDI deployment took to long, trying to continue.");
          }

--- a/camel-microservice-provider/pom.xml
+++ b/camel-microservice-provider/pom.xml
@@ -17,10 +17,6 @@
          <groupId>org.apache.camel</groupId>
          <artifactId>camel-core</artifactId>
       </dependency>
-      <dependency>
-         <groupId>com.fasterxml.jackson.core</groupId>
-         <artifactId>jackson-databind</artifactId>
-      </dependency>
    </dependencies>
    <build>
       <plugins>

--- a/cdi-microservice-provider/pom.xml
+++ b/cdi-microservice-provider/pom.xml
@@ -22,24 +22,8 @@
          <artifactId>weld-se</artifactId>
       </dependency>
       <dependency>
-         <groupId>javax.ejb</groupId>
-         <artifactId>ejb-api</artifactId>
-      </dependency>
-      <dependency>
          <groupId>org.javassist</groupId>
          <artifactId>javassist</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>io.vertx</groupId>
-         <artifactId>vertx-core</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>io.vertx</groupId>
-         <artifactId>vertx-web</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>commons-beanutils</groupId>
-         <artifactId>commons-beanutils</artifactId>
       </dependency>
       <dependency>
          <groupId>org.jmockit</groupId>

--- a/cdi-microservice-provider/src/main/java/io/silverware/microservices/providers/cdi/util/VersionResolver.java
+++ b/cdi-microservice-provider/src/main/java/io/silverware/microservices/providers/cdi/util/VersionResolver.java
@@ -1,8 +1,8 @@
 /*
  * -----------------------------------------------------------------------\
  * SilverWare
- *  
- * Copyright (C) 2015 - 2016 the original author or authors.
+ *
+ * Copyright (C) 2016 - 2017 the original author or authors.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,8 +38,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import io.netty.util.internal.StringUtil;
 
 /**
  * This class is used for resolving of api and implementation versions.
@@ -176,7 +174,7 @@ public final class VersionResolver {
       Class[] interfaces = clazz.getInterfaces();
       List<String> versions = Arrays.stream(interfaces)
                                     .map(i -> resolveVersionFromAnnotations(Arrays.stream(i.getAnnotations()), lambda))
-                                    .filter(v -> !StringUtil.isNullOrEmpty(v))
+                                    .filter(v -> v != null && !v.isEmpty())
                                     .collect(toList());
       if (versions.size() > 1) {
          throw new IllegalArgumentException(String.format(MORE_MICROSERVICE_VERSIONS_FOUND, clazz.getName()));

--- a/http-invoker-microservice-provider/pom.xml
+++ b/http-invoker-microservice-provider/pom.xml
@@ -26,10 +26,6 @@
          <scope>test</scope>
       </dependency>
       <dependency>
-         <groupId>org.javassist</groupId>
-         <artifactId>javassist</artifactId>
-      </dependency>
-      <dependency>
          <groupId>com.cedarsoftware</groupId>
          <artifactId>json-io</artifactId>
       </dependency>

--- a/hystrix-microservice-provider/pom.xml
+++ b/hystrix-microservice-provider/pom.xml
@@ -17,6 +17,10 @@
       <!-- internal -->
       <dependency>
          <groupId>io.silverware</groupId>
+         <artifactId>microservices</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>io.silverware</groupId>
          <artifactId>cdi-microservice-provider</artifactId>
       </dependency>
       <dependency>

--- a/microservices-bom/pom.xml
+++ b/microservices-bom/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+      xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <modelVersion>4.0.0</modelVersion>
    <groupId>io.silverware</groupId>
    <artifactId>microservices-bom</artifactId>
@@ -51,34 +51,36 @@
       </repository>
    </distributionManagement>
    <properties>
-      <version.maven.gpg.plugin>1.5</version.maven.gpg.plugin>
+      <version.maven.gpg.plugin>1.6</version.maven.gpg.plugin>
 
       <version.reflections>0.9.10</version.reflections>
-      <version.log4j>2.5</version.log4j>
-      <version.testng>6.9.10</version.testng>
-      <version.apache.camel>2.16.1</version.apache.camel>
-      <version.slf4j>1.7.13</version.slf4j>
+      <version.log4j>2.7</version.log4j>
+      <version.testng>6.10</version.testng>
+      <version.apache.camel>2.18.1</version.apache.camel>
+      <version.slf4j>1.7.22</version.slf4j>
       <version.weld>2.4.1.Final</version.weld>
       <version.ejb.api>3.0</version.ejb.api>
       <version.jboss.logging>3.3.0.Final</version.jboss.logging>
-      <version.jgroups>3.6.6.Final</version.jgroups>
+      <version.jgroups>3.6.12.Final</version.jgroups>
       <version.commons.cli>1.3.1</version.commons.cli>
-      <version.commons.lang>3.4</version.commons.lang>
-      <version.findbugs>1.3.2</version.findbugs>
-      <version.javassist>3.20.0-GA</version.javassist>
-      <version.undertow>1.4.4.Final</version.undertow>
-      <version.jolokia>1.3.2</version.jolokia>
-      <version.jackson>2.6.4</version.jackson>
-      <version.vertx>3.2.0</version.vertx>
-      <version.jsonio>4.3.0</version.jsonio>
-      <version.beanutils>1.9.2</version.beanutils>
+      <version.commons.lang>3.5</version.commons.lang>
+      <version.findbugs>2.0.1</version.findbugs>
+      <version.javassist>3.21.0-GA</version.javassist>
+      <version.undertow>1.4.8.Final</version.undertow>
+      <version.jolokia>1.3.5</version.jolokia>
+      <version.jackson>2.7.8</version.jackson>
+      <version.vertx>3.3.3</version.vertx>
+      <version.jsonio>4.9.6</version.jsonio>
+      <version.beanutils>1.9.3</version.beanutils>
       <version.drools>6.5.0.Final</version.drools>
-      <version.jmockit>1.29</version.jmockit>
+      <version.jmockit>1.30</version.jmockit>
       <version.assertj>3.5.2</version.assertj>
-      <version.resteasy>3.0.19.Final</version.resteasy>
+      <version.resteasy>3.1.0.Final</version.resteasy>
       <version.sem.ver>2.0.1</version.sem.ver>
       <version.hystrix>1.5.9</version.hystrix>
-      <version.mockito>2.2.22</version.mockito>
+      <version.mockito>2.6.3</version.mockito>
+      <version.activemq>5.14.3</version.activemq>
+      <version.activemq.artemis>1.5.1</version.activemq.artemis>
       <java.level>1.8</java.level>
    </properties>
    <dependencyManagement>
@@ -152,6 +154,21 @@
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
             <version>${version.reflections}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>activemq-all</artifactId>
+            <version>${version.activemq}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-jms-client</artifactId>
+            <version>${version.activemq.artemis}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-jms-server</artifactId>
+            <version>${version.activemq.artemis}</version>
          </dependency>
          <dependency>
             <groupId>org.apache.logging.log4j</groupId>
@@ -268,7 +285,7 @@
             <version>${version.commons.lang}</version>
          </dependency>
          <dependency>
-            <groupId>net.sourceforge.findbugs</groupId>
+            <groupId>com.google.code.findbugs</groupId>
             <artifactId>annotations</artifactId>
             <version>${version.findbugs}</version>
             <scope>provided</scope>
@@ -306,6 +323,11 @@
          </dependency>
          <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${version.jackson}</version>
+         </dependency>
+         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${version.jackson}</version>
          </dependency>
@@ -327,6 +349,16 @@
          <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web</artifactId>
+            <version>${version.vertx}</version>
+         </dependency>
+         <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-lang-groovy</artifactId>
+            <version>${version.vertx}</version>
+         </dependency>
+         <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-lang-js</artifactId>
             <version>${version.vertx}</version>
          </dependency>
          <dependency>

--- a/microservices/pom.xml
+++ b/microservices/pom.xml
@@ -22,6 +22,10 @@
          <artifactId>json-io</artifactId>
       </dependency>
       <dependency>
+         <groupId>com.google.code.findbugs</groupId>
+         <artifactId>annotations</artifactId>
+      </dependency>
+      <dependency>
          <groupId>com.vdurmont</groupId>
          <artifactId>semver4j</artifactId>
       </dependency>

--- a/microservices/src/main/java/io/silverware/microservices/Boot.java
+++ b/microservices/src/main/java/io/silverware/microservices/Boot.java
@@ -2,7 +2,7 @@
  * -----------------------------------------------------------------------\
  * SilverWare
  *  
- * Copyright (C) 2015 the original author or authors.
+ * Copyright (C) 2015 - 2017 the original author or authors.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,12 +40,14 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Properties;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Main class to boot the Microservices platforms.
  *
  * @author <a href="mailto:marvenec@gmail.com">Martin Večeřa</a>
  */
-@edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "DM_EXIT", justification = "This class is allowed to terminate the JVM.")
+@SuppressFBWarnings(value = "DM_EXIT", justification = "This class is allowed to terminate the JVM.")
 public final class Boot {
 
    private static final Logger log = LogManager.getLogger(Boot.class);

--- a/pom.xml
+++ b/pom.xml
@@ -124,11 +124,6 @@
          <artifactId>testng</artifactId>
          <scope>test</scope>
       </dependency>
-      <dependency>
-         <groupId>net.sourceforge.findbugs</groupId>
-         <artifactId>annotations</artifactId>
-         <scope>provided</scope>
-      </dependency>
    </dependencies>
    <build>
       <plugins>

--- a/vertx-microservice-provider/pom.xml
+++ b/vertx-microservice-provider/pom.xml
@@ -16,7 +16,6 @@
    <properties>
       <version.gmaven>1.5</version.gmaven>
       <version.groovy>2.4.6</version.groovy>
-      <version.vertx.extension>3.2.0</version.vertx.extension>
    </properties>
 
    <dependencies>
@@ -31,12 +30,10 @@
       <dependency>
          <groupId>io.vertx</groupId>
          <artifactId>vertx-lang-groovy</artifactId>
-         <version>${version.vertx.extension}</version>
       </dependency>
       <dependency>
          <groupId>io.vertx</groupId>
          <artifactId>vertx-lang-js</artifactId>
-         <version>${version.vertx.extension}</version>
          <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
I have updated all dependencies to the latest version except for AssertJ which contains some bug causing test failures and Jackson which breaks Vert.x tests.

I have also removed unnecessary dependencies from some modules and reduced the size of default CDI + HTTP server package from 21 MB to 17.5 MB.